### PR TITLE
Log cyipopt messages to the 'cyipopt' logging namespace

### DIFF
--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -38,7 +38,7 @@ def setLoggingLevel(level=None):
     global verbosity
 
     if not level:
-        logger = logging.getLogger()
+        logger = logging.getLogger('cyipopt')
         verbosity = logger.getEffectiveLevel()
     else:
         verbosity = level
@@ -47,7 +47,7 @@ setLoggingLevel()
 
 cdef inline void log(char* msg, int level):
      if level >= verbosity:
-         logging.log(level, msg)
+         logging.getLogger('cyipopt').log(level, msg)
 
 STATUS_MESSAGES = {
     Solve_Succeeded: b'Algorithm terminated successfully at a locally optimal point, satisfying the convergence tolerances (can be specified by options).',


### PR DESCRIPTION
Currently `cyipopt` logs messages to the Python root logging namespace.  This makes it challenging when building larger applications that embed `cyipopt`, as you cannot for example easily enable `INFO` logging for the application without also also getting `INFO` log messages from `cyipopt`.

This PR moves `cyipopt` logging into the `'cyipopt'` logging namespace to allow users more fine-grained control of the logged messages.