### PR TITLE
Add support for objective and constraint hessians and `jac=True` option for constraints in the scipy interface

### DIFF
--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -363,7 +363,7 @@ cdef class Problem:
             raise ValueError(msg)
 
         cdef Index nele_jac = self.__m * self.__n
-        cdef Index nele_hess = <Index>(<long>self.__n * (<long>self.__n - 1) / 2)
+        cdef Index nele_hess = <Index>(<long>self.__n * (<long>self.__n + 1) / 2)
 
         if self.__jacobianstructure:
             ret_val = self.__jacobianstructure()

--- a/cyipopt/ipopt_wrapper.py
+++ b/cyipopt/ipopt_wrapper.py
@@ -5,7 +5,7 @@ import warnings
 from .scipy_interface import IpoptProblemWrapper as CyipoptIpoptProblemWrapper
 from .scipy_interface import convert_to_bytes as cyipopt_convert_to_bytes
 from .scipy_interface import get_bounds as cyipopt_get_bounds
-from .scipy_interface import get_constraint_bounds_and_dimensions as cyipopt_get_constraint_bounds
+from .scipy_interface import get_constraint_bounds as cyipopt_get_constraint_bounds
 from .scipy_interface import minimize_ipopt as cyipopt_minimize_ipopt
 
 

--- a/cyipopt/ipopt_wrapper.py
+++ b/cyipopt/ipopt_wrapper.py
@@ -5,7 +5,7 @@ import warnings
 from .scipy_interface import IpoptProblemWrapper as CyipoptIpoptProblemWrapper
 from .scipy_interface import convert_to_bytes as cyipopt_convert_to_bytes
 from .scipy_interface import get_bounds as cyipopt_get_bounds
-from .scipy_interface import get_constraint_bounds as cyipopt_get_constraint_bounds
+from .scipy_interface import get_constraint_bounds_and_dimensions as cyipopt_get_constraint_bounds
 from .scipy_interface import minimize_ipopt as cyipopt_minimize_ipopt
 
 

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -164,15 +164,15 @@ def get_bounds(bounds):
         return lb, ub
 
 
-def get_constraint_bounds(constraints, x0, INF=1e19):
-    if isinstance(constraints, dict):
-        constraints = (constraints, )
+def get_constraint_bounds_and_dimensions(constraints, x0, INF=1e19):
     cl = []
     cu = []
+    con_dims = []
     if isinstance(constraints, dict):
         constraints = (constraints, )
     for con in constraints:
         m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))))
+        con_dims.append(m)
         cl.extend(np.zeros(m))
         if con['type'] == 'eq':
             cu.extend(np.zeros(m))
@@ -182,8 +182,9 @@ def get_constraint_bounds(constraints, x0, INF=1e19):
             raise ValueError(con['type'])
     cl = np.array(cl)
     cu = np.array(cu)
+    con_dims = np.array(con_dims)
 
-    return cl, cu
+    return cl, cu, con_dims
 
 
 def replace_option(options, oldname, newname):

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -106,7 +106,7 @@ class IpoptProblemWrapper(object):
         self._constraint_dims = np.asarray(con_dims)
         self._constraint_args = []
         self._constraint_kwargs = []
-        self.last_con_values = [(None, None) for _ in range(len(constraints))]
+        self._last_con_values = [(None, None) for _ in range(len(constraints))]
         if isinstance(constraints, dict):
             constraints = (constraints, )
         for con in constraints:
@@ -182,8 +182,8 @@ class IpoptProblemWrapper(object):
     def _evaluate_con_fun_with_jac(self, i, con_fun, x, *args):
         if self.last_x is None or not np.all(self.last_x == x):
             self.last_x = x
-            self.last_con_values[i] = con_fun(x, *args)
-        return self.last_con_values[i]
+            self._last_con_values[i] = con_fun(x, *args)
+        return self._last_con_values[i]
 
     def hessianstructure(self):
         return np.nonzero(np.tril(np.ones((self.n, self.n))))  # type: ignore

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -163,7 +163,7 @@ class IpoptProblemWrapper(object):
                 zip(self._constraint_funs, self._constraint_args)):
             if self._constraint_funs_with_jacs[i]:
                 con_values.append(
-                    self.__evaluate_con_fun_with_jac(i, fun, x, *args)[0])
+                    self._evaluate_con_fun_with_jac(i, fun, x, *args)[0])
             else:
                 con_values.append(fun(x, *args))
         return np.hstack(con_values)
@@ -174,19 +174,19 @@ class IpoptProblemWrapper(object):
                 zip(self._constraint_funs, self._constraint_jacs, self._constraint_args)):
             if self._constraint_funs_with_jacs[i]:
                 con_values.append(
-                    self.__evaluate_con_fun_with_jac(i, fun, x, *args)[1])
+                    self._evaluate_con_fun_with_jac(i, fun, x, *args)[1])
             else:
                 con_values.append(jac(x, *args))
         return np.vstack(con_values)
 
-    def __evaluate_con_fun_with_jac(self, i, con_fun, x, *args):
+    def _evaluate_con_fun_with_jac(self, i, con_fun, x, *args):
         if self.last_x is None or not np.all(self.last_x == x):
             self.last_x = x
             self.last_con_values[i] = con_fun(x, *args)
         return self.last_con_values[i]
 
     def hessianstructure(self):
-        return np.nonzero(np.tril(np.ones((self.n, self.n)))) # type: ignore
+        return np.nonzero(np.tril(np.ones((self.n, self.n))))  # type: ignore
 
     def hessian(self, x, lagrange, obj_factor):
         obj_h = obj_factor * self.obj_hess(x)  # type: ignore

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -234,7 +234,10 @@ def get_constraint_bounds(constraints, x0, INF=1e19):
     if isinstance(constraints, dict):
         constraints = (constraints, )
     for con in constraints:
-        m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))))
+        if con.get('jac', False) is True:
+            m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))[0]))
+        else:
+            m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))))
         cl.extend(np.zeros(m))
         if con['type'] == 'eq':
             cu.extend(np.zeros(m))

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -112,7 +112,6 @@ class IpoptProblemWrapper(object):
         for con in constraints:
             con_fun = con['fun']
             con_jac = con.get('jac', None)
-            con_fun_with_jac = True if con_jac is True else False
             con_args = con.get('args', [])
             con_hessian = con.get('hess', None)
             con_kwargs = con.get('kwargs', [])

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -122,6 +122,8 @@ def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy(
     np.testing.assert_allclose(res.get("x"), expected_res, rtol=1e-5)
 
 
+@pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_hs071():
     """ `minimize_ipopt` works with objective gradient and Hessian
         and constraint jacobians and Hessians. The objective and

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -79,15 +79,40 @@ def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy():
          and constarint jacobians and Hessians"""
     from scipy.optimize import rosen, rosen_der, rosen_hess
     x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
-    constr = {"fun": lambda x: rosen(x) - 1.0, "type": "ineq", 
+    constr = {"fun": lambda x: rosen(x) - 1.0, "type": "ineq",
               'jac': rosen_der, 'hess': lambda x, v: rosen_hess(x) * v[0]}
-    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess, 
+    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess,
                                  constraints=constr)
     print(res.fun)
     assert isinstance(res, dict)
     assert np.isclose(res.get("fun"), 1.0828541)
     assert res.get("status") == 0
     assert res.get("success") is True
-    expected_res = np.array([1.09022019, 1.14568613, 1.30965199, 1.71962948, 
+    expected_res = np.array([1.09022019, 1.14568613, 1.30965199, 1.71962948,
                              2.90683532])
+    np.testing.assert_allclose(res.get("x"), expected_res)
+
+
+@pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid if Scipy available.")
+def test_minimize_ipopt_constraint_jac_true_if_scipy():
+    """ `minimize_ipopt` works with objective gradient and Hessian 
+         and constarint jacobians and Hessians"""
+    from scipy.optimize import rosen, rosen_der
+    x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
+    constr = {
+        "fun": lambda x: (rosen(x) - 2.0, rosen_der(x)),
+        "type": "ineq",
+        'jac': True,
+    }
+    res = cyipopt.minimize_ipopt(rosen, x0,
+                                 jac=rosen_der,
+                                 constraints=constr)
+    print(res.fun)
+    assert isinstance(res, dict)
+    assert np.isclose(res.get("fun"), 2.0)
+    assert res.get("status") == 0
+    assert res.get("success") is True
+    expected_res = np.array(
+        [1.0040163, 0.9791639, 1.04011872, 1.18788545, 1.38059278])
     np.testing.assert_allclose(res.get("x"), expected_res)

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -75,15 +75,14 @@ def test_minimize_ipopt_nojac_constraints_if_scipy():
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy():
-    """ `minimize_ipopt` works with objective gradient and Hessian 
-         and constraint jacobians and Hessians"""
+    """`minimize_ipopt` works with objective gradient and Hessian 
+       and constraint jacobians and Hessians."""
     from scipy.optimize import rosen, rosen_der, rosen_hess
     x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
     constr = {"fun": lambda x: rosen(x) - 1.0, "type": "ineq",
-              'jac': rosen_der, 'hess': lambda x, v: rosen_hess(x) * v[0]}
+              "jac": rosen_der, "hess": lambda x, v: rosen_hess(x) * v[0]}
     res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess,
                                  constraints=constr)
-    print(res.fun)
     assert isinstance(res, dict)
     assert np.isclose(res.get("fun"), 1.0828541)
     assert res.get("status") == 0
@@ -103,12 +102,11 @@ def test_minimize_ipopt_constraint_jac_true_if_scipy():
     constr = {
         "fun": lambda x: (rosen(x) - 2.0, rosen_der(x)),
         "type": "ineq",
-        'jac': True,
+        "jac": True,
     }
     res = cyipopt.minimize_ipopt(rosen, x0,
                                  jac=rosen_der,
                                  constraints=constr)
-    print(res.fun)
     assert isinstance(res, dict)
     assert np.isclose(res.get("fun"), 2.0)
     assert res.get("status") == 0

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -74,31 +74,6 @@ def test_minimize_ipopt_nojac_constraints_if_scipy():
 
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
-def test_minimize_ipopt_jac_and_hessians_constraints_monotone_strategy_if_scipy():
-    """`minimize_ipopt` works with objective gradient and Hessian 
-       and constraint jacobians and Hessians."""
-    # Note: the default Ipopt 'mu_strategy' is 'monotone' instead of 'adaptive'.
-    from scipy.optimize import rosen, rosen_der, rosen_hess
-    x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
-    constr = {
-        "fun": lambda x: rosen(x) - 1.0,
-        "type": "ineq",
-        "jac": rosen_der,
-        "hess": lambda x, v: rosen_hess(x) * v[0]
-    }
-    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess,
-                                 constraints=constr,
-                                 options={'mu_strategy': 'monotone'})
-    assert isinstance(res, dict)
-    assert np.isclose(res.get("fun"), 1.0)
-    assert res.get("status") == 0
-    assert res.get("success") is True
-    expected_res = np.array([1.087746, 1.143973, 1.306229, 1.710728, 2.880089])
-    np.testing.assert_allclose(res.get("x"), expected_res, rtol=1e-6)
-
-
-@pytest.mark.skipif("scipy" not in sys.modules,
-                    reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy(
 ):
     """`minimize_ipopt` works with objective gradient and Hessian 

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -100,18 +100,18 @@ def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy(
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_hs071():
-    """ `minimize_ipopt` works with objective gradient and Hessian
-        and constraint jacobians and Hessians. The objective and
-        the constraints functions return a tuple containing the
-        function value and the evaluated gradient or jacobian.
+    """ `minimize_ipopt` works with objective gradient and Hessian and 
+         constraint jacobians and Hessians.
+
+        The objective and the constraints functions return a tuple containing 
+        the function value and the evaluated gradient or jacobian. Solves
+        Hock & Schittkowski's test problem 71:
+
+        min x0*x3*(x0+x1+x2)+x2
+        s.t. x0**2 + x1**2 + x2**2 + x3**2 - 40  = 0
+                         x0 * x1 * x2 * x3 - 25 >= 0
+                               1 <= x0,x1,x2,x3 <= 5
     """
-    # Hock & Schittkowski test problem 71
-    #
-    # min x0*x3*(x0+x1+x2)+x2
-    #
-    # s.t. x0**2 + x1**2 + x2**2 + x3**2 - 40 = 0
-    #      x0 * x1 * x2 * x3 - 25 >= 0
-    #      1 <= x0,x1,x2,x3 <= 5
 
     def obj_and_grad(x):
         obj = x[0] * x[3] * np.sum(x[:3]) + x[2]

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -70,3 +70,22 @@ def test_minimize_ipopt_nojac_constraints_if_scipy():
     expected_res = np.array([1.001867, 0.99434067, 1.05070075, 1.17906312,
                              1.38103001])
     np.testing.assert_allclose(res.get("x"), expected_res)
+
+
+@pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid if Scipy available.")
+def test_minimize_ipopt_jac_constraints_if_scipy():
+    """ `minimize_ipopt` works with objective gradient and Hessian 
+         and constarint jacobians and Hessians"""
+    from scipy.optimize import rosen, rosen_der, rosen_hess
+    x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
+    constr = {"fun": lambda x: rosen(x) - 1.0, "type": "ineq", 
+              'jac': rosen_der, 'hess': lambda x, v: rosen_hess(x) * v[0]}
+    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess, constraints=constr)
+    print(res.fun)
+    assert isinstance(res, dict)
+    assert np.isclose(res.get("fun"), 1.0828541)
+    assert res.get("status") == 0
+    assert res.get("success") is True
+    expected_res = np.array([1.09022019, 1.14568613, 1.30965199, 1.71962948, 2.90683532])
+    np.testing.assert_allclose(res.get("x"), expected_res)

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -74,18 +74,20 @@ def test_minimize_ipopt_nojac_constraints_if_scipy():
 
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
-def test_minimize_ipopt_jac_constraints_if_scipy():
+def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy():
     """ `minimize_ipopt` works with objective gradient and Hessian 
          and constarint jacobians and Hessians"""
     from scipy.optimize import rosen, rosen_der, rosen_hess
     x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
     constr = {"fun": lambda x: rosen(x) - 1.0, "type": "ineq", 
               'jac': rosen_der, 'hess': lambda x, v: rosen_hess(x) * v[0]}
-    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess, constraints=constr)
+    res = cyipopt.minimize_ipopt(rosen, x0, jac=rosen_der, hess=rosen_hess, 
+                                 constraints=constr)
     print(res.fun)
     assert isinstance(res, dict)
     assert np.isclose(res.get("fun"), 1.0828541)
     assert res.get("status") == 0
     assert res.get("success") is True
-    expected_res = np.array([1.09022019, 1.14568613, 1.30965199, 1.71962948, 2.90683532])
+    expected_res = np.array([1.09022019, 1.14568613, 1.30965199, 1.71962948, 
+                             2.90683532])
     np.testing.assert_allclose(res.get("x"), expected_res)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -89,15 +89,21 @@ Next, we build the derivatives and just-in-time (jit) compile the functions
    con_ineq_jit = jit(ineq_constrains)
 
    # build the derivatives and jit them
-   obj_grad = jit(grad(obj_jit))  # gradient
+   obj_grad = jit(grad(obj_jit))  # objective gradient
+   obj_hess = jit(jacrev(jacfwd(obj_jit))) # objective hessian
    con_eq_jac = jit(jacfwd(con_eq_jit))  # jacobian
    con_ineq_jac = jit(jacfwd(con_ineq_jit))  # jacobian
+   con_eq_hess = jacrev(jacfwd(con_eq_jit)) # hessian
+   con_eq_hessvp = jit(lambda x, v: con_eq_hess(x) * v[0]) # hessian vector-product
+   con_ineq_hess = jacrev(jacfwd(con_ineq_jit))  # hessian
+   con_ineq_hessvp = jit(lambda x, v: con_ineq_hess(x) * v[0]) # hessian vector-product
+
 
 Finally, we can call ``minimize_ipopt`` similar to ``scipy.optimize.minimize``::
 
    # constraints
-   cons = [{'type': 'eq', 'fun': con_eq_jit, 'jac': con_eq_jac},
-       {'type': 'ineq', 'fun': con_ineq_jit, 'jac': con_ineq_jac}]
+   cons = [{'type': 'eq', 'fun': con_eq_jit, 'jac': con_eq_jac, 'hess': con_eq_hess},
+       {'type': 'ineq', 'fun': con_ineq_jit, 'jac': con_ineq_jac, 'hess': con_ineq_hess}]
 
    # starting point
    x0 = np.array([1, 5, 5, 1])
@@ -106,7 +112,7 @@ Finally, we can call ``minimize_ipopt`` similar to ``scipy.optimize.minimize``::
    bnds = [(1, 5) for _ in range(x0.size)]
 
    # executing the solver
-   res = minimize_ipopt(obj_jit, jac=obj_grad, x0=x0, bounds=bnds,
+   res = minimize_ipopt(obj_jit, jac=obj_grad, hess=obj_hess, x0=x0, bounds=bnds,
                      constraints=cons, options={'disp': 5})
 
 Problem Interface

--- a/examples/hs071_scipy_jax.py
+++ b/examples/hs071_scipy_jax.py
@@ -2,7 +2,7 @@
 
 import jax.numpy as np
 import jax
-from jax import jit, grad, jacfwd
+from jax import jit, grad, jacfwd, jacrev
 from cyipopt import minimize_ipopt
 
 # Test the scipy interface on the Hock & Schittkowski test problem 71:
@@ -38,14 +38,19 @@ con_eq_jit = jit(eq_constraints)
 con_ineq_jit = jit(ineq_constrains)
 
 # build the derivatives and jit them
-obj_grad = jit(grad(obj_jit))  # gradient
+obj_grad = jit(grad(obj_jit))  # objective gradient
+obj_hess = jit(jacrev(jacfwd(obj_jit))) # objective hessian
 con_eq_jac = jit(jacfwd(con_eq_jit))  # jacobian
 con_ineq_jac = jit(jacfwd(con_ineq_jit))  # jacobian
+con_eq_hess = jacrev(jacfwd(con_eq_jit)) # hessian
+con_eq_hessvp = jit(lambda x, v: con_eq_hess(x) * v[0]) # hessian vector-product
+con_ineq_hess = jacrev(jacfwd(con_ineq_jit))  # hessian
+con_ineq_hessvp = jit(lambda x, v: con_ineq_hess(x) * v[0]) # hessian vector-product
 
 # constraints
 cons = [
-    {'type': 'eq', 'fun': con_eq_jit, 'jac': con_eq_jac},
-    {'type': 'ineq', 'fun': con_ineq_jit, 'jac': con_ineq_jac},
+    {'type': 'eq', 'fun': con_eq_jit, 'jac': con_eq_jac, 'hess': con_eq_hessvp},
+    {'type': 'ineq', 'fun': con_ineq_jit, 'jac': con_ineq_jac, 'hess': con_ineq_hessvp},
 ]
 
 # initial guess
@@ -54,5 +59,7 @@ x0 = np.array([1, 5, 5, 1])
 # variable bounds: 1 <= x[i] <= 5
 bnds = [(1, 5) for _ in range(x0.size)]
 
-res = minimize_ipopt(obj_jit, jac=obj_grad, x0=x0, bounds=bnds,
+res = minimize_ipopt(obj_jit, jac=obj_grad, hess=obj_hess, x0=x0, bounds=bnds,
                      constraints=cons, options={'disp': 5})
+
+print(res)

--- a/examples/hs071_scipy_jax.py
+++ b/examples/hs071_scipy_jax.py
@@ -39,13 +39,13 @@ con_ineq_jit = jit(ineq_constrains)
 
 # build the derivatives and jit them
 obj_grad = jit(grad(obj_jit))  # objective gradient
-obj_hess = jit(jacrev(jacfwd(obj_jit))) # objective hessian
+obj_hess = jit(jacrev(jacfwd(obj_jit)))  # objective hessian
 con_eq_jac = jit(jacfwd(con_eq_jit))  # jacobian
 con_ineq_jac = jit(jacfwd(con_ineq_jit))  # jacobian
 con_eq_hess = jacrev(jacfwd(con_eq_jit)) # hessian
 con_eq_hessvp = jit(lambda x, v: con_eq_hess(x) * v[0]) # hessian vector-product
 con_ineq_hess = jacrev(jacfwd(con_ineq_jit))  # hessian
-con_ineq_hessvp = jit(lambda x, v: con_ineq_hess(x) * v[0]) # hessian vector-product
+con_ineq_hessvp = jit(lambda x, v: con_ineq_hess(x) * v[0])  # hessian vector-product
 
 # constraints
 cons = [


### PR DESCRIPTION
Implements #99 and #122.

- Adds support for objective hessian and constraint Hessians through an additional `hess` field in the constraint dictionary.  The hessian must have the signature `hess(x,v) -> np.ndarray` and return `v[0] * Hg1_(x) + ... + v[m-1] * Hg_m(x)`. Here, `v` is the np.ndarray with shape `m` containing the lagrangian multipliers for the constraint and `Hg_i` denotes the hessian matrix of the constraint component `g_i : R^N -> R`.

Current limitations:
- No support for NonlinearConstraint objects.
- No support for objective hessian matrix-vector product `hessp`.
- In case one passes the hessian for at least one constraint or the objective, we need the Hessians for all constraints and the objective.