### PR TITLE
Add support for IPOPT `Maximum_WallTime_Exceeded` status message

### DIFF
--- a/cyipopt/cython/ipopt.pxd
+++ b/cyipopt/cython/ipopt.pxd
@@ -38,7 +38,7 @@ cdef extern from "IpStdCInterface.h":
         Restoration_Failed=-2
         Error_In_Step_Computation=-3
         Maximum_CpuTime_Exceeded=-4
-        Maximum_WallClockTime_Exceeded=-5
+        Maximum_WallTime_Exceeded=-5
         Not_Enough_Degrees_Of_Freedom=-10
         Invalid_Problem_Definition=-11
         Invalid_Option=-12

--- a/cyipopt/cython/ipopt.pxd
+++ b/cyipopt/cython/ipopt.pxd
@@ -38,6 +38,7 @@ cdef extern from "IpStdCInterface.h":
         Restoration_Failed=-2
         Error_In_Step_Computation=-3
         Maximum_CpuTime_Exceeded=-4
+        Maximum_WallClockTime_Exceeded=-5
         Not_Enough_Degrees_Of_Freedom=-10
         Invalid_Problem_Definition=-11
         Invalid_Option=-12

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -102,6 +102,7 @@ STATUS_MESSAGES = {
     Error_In_Step_Computation: (b"An unrecoverable error occurred while Ipopt "
                                 b"tried to compute the search direction."),
     Maximum_CpuTime_Exceeded: b"Maximum CPU time exceeded.",
+    Maximum_WallClockTime_Exceeded: b"Maximum wallclock time exceeded.",
     Not_Enough_Degrees_Of_Freedom: b"Problem has too few degrees of freedom.",
     Invalid_Problem_Definition: b"Invalid problem definition.",
     Invalid_Option: b"Invalid option encountered.",
@@ -649,7 +650,7 @@ cdef class Problem:
                 "mult_x_L": mult_x_L,
                 "mult_x_U": mult_x_U,
                 "status": stat,
-                "status_msg": STATUS_MESSAGES[stat]
+                "status_msg": STATUS_MESSAGES.get(stat, b"Unknown status")
                 }
 
         return np_x, info

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -102,7 +102,7 @@ STATUS_MESSAGES = {
     Error_In_Step_Computation: (b"An unrecoverable error occurred while Ipopt "
                                 b"tried to compute the search direction."),
     Maximum_CpuTime_Exceeded: b"Maximum CPU time exceeded.",
-    Maximum_WallClockTime_Exceeded: b"Maximum wallclock time exceeded.",
+    Maximum_WallTime_Exceeded: b"Maximum wallclock time exceeded.",
     Not_Enough_Degrees_Of_Freedom: b"Problem has too few degrees of freedom.",
     Invalid_Problem_Definition: b"Invalid problem definition.",
     Invalid_Option: b"Invalid option encountered.",

--- a/cyipopt/tests/unit/test_options.py
+++ b/cyipopt/tests/unit/test_options.py
@@ -2,7 +2,7 @@ def test_maximum_cpu_time_exceeded(
     hs071_initial_guess_fixture, hs071_problem_instance_fixture
 ):
     """Test whether cyipopt properly can handle the
-    "Maximum_CpuTime_Exceeded" status from IPOPT."""
+    "Maximum_WallTime_Exceeded" status from IPOPT."""
     # Initialize a reference problem.
     x0 = hs071_initial_guess_fixture
     nlp = hs071_problem_instance_fixture

--- a/cyipopt/tests/unit/test_options.py
+++ b/cyipopt/tests/unit/test_options.py
@@ -1,0 +1,16 @@
+def test_maximum_cpu_time_exceeded(
+    hs071_initial_guess_fixture, hs071_problem_instance_fixture
+):
+    """Test whether cyipopt properly can handle the
+    "Maximum_CpuTime_Exceeded" status from IPOPT."""
+    # Initialize a reference problem.
+    x0 = hs071_initial_guess_fixture
+    nlp = hs071_problem_instance_fixture
+
+    # Set a ridiculously low wall time limit.
+    nlp.add_option("max_wall_time", 1e-10)
+
+    # Solve the problem and ensure that the correct IPOPT return status
+    # is set.
+    _, info = nlp.solve(x0)
+    assert info["status"] == -5


### PR DESCRIPTION
In addition, add status message for "maximum wallclock time exceeded" status.

This PR is motivated by [this issue (cyipopt throws KeyError when IPOPT exceeds max_wall_time)](https://github.com/mechmotum/cyipopt/issues/131).