### PR TITLE
Avoid KeyError upon unknown IPOPT return statuses.

### DIFF
--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -649,7 +649,7 @@ cdef class Problem:
                 "mult_x_L": mult_x_L,
                 "mult_x_U": mult_x_U,
                 "status": stat,
-                "status_msg": STATUS_MESSAGES[stat]
+                "status_msg": STATUS_MESSAGES.get(stat, b"Unknown status")
                 }
 
         return np_x, info


### PR DESCRIPTION
Follow-up PR as discussed in [this thread](https://github.com/mechmotum/cyipopt/pull/132). It's basically just a one-line change to avoid KeyErrors in case IPOPT returns a status that `cyipopt` cannot (yet) deal with.

Side-note: I considered adding a test for this, somewhat along the lines of
```python
import ipopt_wrapper


def test_unknown_ipopt_status(
    monkeypatch, hs071_initial_guess_fixture, hs071_problem_instance_fixture
):
    """Check if cyipopt is able to gracefully handle unknown IPOPT
    statuses.
    """
    # Set some arbitrary "unknown" status code and make sure that it
    # really is unknown to cyipopt.
    unknown_status = -42
    assert unknown_status not in ipopt_wrapper.STATUS_MESSAGES

    # Monkey patch the call to the IPOPT solver to just instantly return
    # the unknown status code.
    def mock_solve(*args, **kwargs):
        return unknown_status

    # WILL NOT WORK -> IpoptSolve is "hidden".
    monkeypatch.setattr(ipopt_wrapper, "IpoptSolve", mock_solve)

    # Solve a sample problem and check for the final status message.
    x0 = hs071_initial_guess_fixture
    nlp = hs071_problem_instance_fixture
    _, info = nlp.solve(x0)
    assert info["status_msg"] == b"Unknown status"
```
but it would not work, because it appears you cannot monkey patch a "cimported" function and I do not see any way around this. We could probably get it to work by restructuring the code in `ipopt_wrapper.pyx` a bit further, but maybe that's a bit much of a hassle for a one-line change. What do you think?