### PR TITLE
A little consistency in shebangs and execute bits

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.

--- a/cyipopt/version.py
+++ b/cyipopt/version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.

--- a/examples/exception_handling.py
+++ b/examples/exception_handling.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.

--- a/examples/hs071.py
+++ b/examples/hs071.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.

--- a/examples/hs071_scipy_jax.py
+++ b/examples/hs071_scipy_jax.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python3
-
 import jax.numpy as np
 import jax
 from jax import jit, grad, jacfwd, jacrev

--- a/examples/lasso.py
+++ b/examples/lasso.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.


### PR DESCRIPTION
Adds a shebang to `examples/rosen.py`, to match the other examples.

Sets execute permission on all files with shebangs—the examples, plus `setup.py`—without which the shebangs have little value.