### PR TITLE
[WIP] Remove deprecated setup.py install approach

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
         conda install -y -q lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
         conda info -a
         conda list
-        python setup.py install
+        python -m pip install .
         python -c "import cyipopt"
         conda install -y -q pytest>=3.3.2
         pytest


### PR DESCRIPTION
This PR is intended to diagnose and fix currently failing CI workflows occurring only with macOS and Python 3.9 (encountered first in PR #146). I hypothesise that this is due to use of [python setup.py install](https://github.com/mechmotum/cyipopt/blob/89401cf28345dd59137b272b95f13f0a6d481886/.github/workflows/test.yml#L31) for package installation becoming [deprecated](https://docs.python.org/3/install/) with the deprecation of distutils in preference of setuptools.

Currently all CI workflows raise related warnings following the call of `python setup.py install`. A copy of a revenant message from a random recent CI run is copied below:

```
[1] Run python setup.py install
[2]   python setup.py install
[3]   shell: /bin/bash -l {0}
[4]   env:
[5]    CONDA_PKGS_DIR: /Users/runner/conda_pkgs_dir
[6] /usr/local/miniconda/envs/test-environment/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
[7] running install
[8]   warnings.warn(
[9] /usr/local/miniconda/envs/test-environment/lib/python3.9/site-packages/setuptools/command/easy_install.py:160: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
```

This PR attempts to resolve the issue seen in PR #146 by replacing the installation command with `python -m pip install .`.