### PR TITLE
Remove deprecated setup.py install approach

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt
-        run: python setup.py install
+        run: python -m pip install .
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
-        ipopt-version: [3.13]
+        python-version: ['3.9']
+        ipopt-version: ['3.13']
     defaults:
       run:
         shell: bash -l {0}
@@ -23,7 +23,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: 3.21.4
+          conda-build-version: '3.21.4'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
-        run: python setup.py install
+        run: python -m pip install .
       - name: Test with pytest
         run: 
           python -c "import cyipopt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
-        ipopt-version: [3.14]
+        python-version: ['3.9']
+        ipopt-version: ['3.14']
     defaults:
       run:
         shell: bash -l {0}
@@ -24,7 +24,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: 3.21.4
+          conda-build-version: '3.21.4'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
-        run: python setup.py install
+        run: python -m pip install .
       - name: Test with pytest
         run: 
           python -c "import cyipopt"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         ipopt-version: [3.12, 3.13, 3.14]
         exclude:
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
-        ipopt-version: [3.12, 3.13, 3.14]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        ipopt-version: ['3.12', '3.13', '3.14']
         exclude:
           - os: windows-latest
-            ipopt-version: 3.12
+            ipopt-version: '3.12'
     defaults:
       run:
         shell: bash -l {0}
@@ -31,7 +31,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: 3.21.4
+          conda-build-version: '3.21.4'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt


### PR DESCRIPTION
This PR is intended to diagnose and fix currently failing CI workflows occurring only with macOS and Python 3.9 (encountered first in PR #146). I hypothesise that this is due to use of [python setup.py install](https://github.com/mechmotum/cyipopt/blob/89401cf28345dd59137b272b95f13f0a6d481886/.github/workflows/test.yml#L31) for package installation becoming [deprecated](https://docs.python.org/3/install/) with the deprecation of distutils in preference of setuptools.

Currently all CI workflows raise related warnings following the call of `python setup.py install`. A copy of a revenant message from a random recent CI run is copied below:

```
[1] Run python setup.py install
[2]   python setup.py install
[3]   shell: /bin/bash -l {0}
[4]   env:
[5]    CONDA_PKGS_DIR: /Users/runner/conda_pkgs_dir
[6] /usr/local/miniconda/envs/test-environment/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
[7] running install
[8]   warnings.warn(
[9] /usr/local/miniconda/envs/test-environment/lib/python3.9/site-packages/setuptools/command/easy_install.py:160: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
```

This PR attempts to resolve the issue seen in PR #146 by replacing the installation command with `python -m pip install .`.