### PR TITLE
Avoid SciPy deprecation warning.

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -22,7 +22,11 @@ else:
     from scipy.optimize import approx_fprime
     try:
         from scipy.optimize import OptimizeResult
-        from scipy.optimize.optimize import MemoizeJac
+        try:
+            from scipy.optimize import MemoizeJac
+        except ImportError:
+            # This is namespace is being depreacted in SciPy
+            from scipy.optimize.optimize import MemoizeJac
     except ImportError:
         # in scipy 0.14 Result was renamed to OptimzeResult
         from scipy.optimize import Result
@@ -60,7 +64,7 @@ class IpoptProblemWrapper(object):
     eps : float, optional
         Epsilon used in finite differences.
     con_dims : array_like, optional
-        Dimensions p_1, ..., p_m of the m constraint functions 
+        Dimensions p_1, ..., p_m of the m constraint functions
         g_1, ..., g_m : R^n -> R^(p_i).
     """
     def __init__(self,

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -22,15 +22,15 @@ else:
     from scipy.optimize import approx_fprime
     try:
         from scipy.optimize import OptimizeResult
-        try:
-            from scipy.optimize import MemoizeJac
-        except ImportError:
-            # This is namespace is being depreacted in SciPy
-            from scipy.optimize.optimize import MemoizeJac
     except ImportError:
-        # in scipy 0.14 Result was renamed to OptimzeResult
+        # in scipy 0.14 Result was renamed to OptimizeResult
         from scipy.optimize import Result
         OptimizeResult = Result
+    try:
+        from scipy.optimize import MemoizeJac
+    except ImportError:
+        # The optimize.optimize namespace is being deprecated
+        from scipy.optimize.optimize import MemoizeJac
 
 import cyipopt
 


### PR DESCRIPTION
```
=========================================== warnings summary ============================================
cyipopt/scipy_interface.py:29
  /home/moorepants/src/cyipopt/cyipopt/scipy_interface.py:29: DeprecationWarning: Please use `MemoizeJac` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated.
    from scipy.optimize.optimize import MemoizeJac

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```