### PR TITLE
Remove use of MemoizeJac

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -26,11 +26,6 @@ else:
         # in scipy 0.14 Result was renamed to OptimizeResult
         from scipy.optimize import Result
         OptimizeResult = Result
-    try:
-        from scipy.optimize import MemoizeJac
-    except ImportError:
-        # The optimize.optimize namespace is being deprecated
-        from scipy.optimize.optimize import MemoizeJac
 
 import cyipopt
 
@@ -91,7 +86,6 @@ class IpoptProblemWrapper(object):
             jac = lambda x0, *args, **kwargs: approx_fprime(
                 x0, fun, eps, *args, **kwargs)
         elif jac is True:
-            fun = MemoizeJac(fun)
             jac = fun.derivative
         elif not callable(jac):
             raise NotImplementedError('jac has to be bool or a function')
@@ -117,7 +111,6 @@ class IpoptProblemWrapper(object):
                 con_jac = lambda x0, *args, **kwargs: approx_fprime(
                     x0, con_fun, eps, *args, **kwargs)
             elif con_jac is True:
-                con_fun = MemoizeJac(con_fun)
                 con_jac = con_fun.derivative
             elif not callable(con_jac):
                 raise NotImplementedError('jac has to be bool or a function')

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -85,8 +85,6 @@ class IpoptProblemWrapper(object):
         if jac is None:
             jac = lambda x0, *args, **kwargs: approx_fprime(
                 x0, fun, eps, *args, **kwargs)
-        elif jac is True:
-            jac = fun.derivative
         elif not callable(jac):
             raise NotImplementedError('jac has to be bool or a function')
         self.fun = fun
@@ -110,10 +108,8 @@ class IpoptProblemWrapper(object):
             if con_jac is None:
                 con_jac = lambda x0, *args, **kwargs: approx_fprime(
                     x0, con_fun, eps, *args, **kwargs)
-            elif con_jac is True:
-                con_jac = con_fun.derivative
             elif not callable(con_jac):
-                raise NotImplementedError('jac has to be bool or a function')
+                raise NotImplementedError('jac has to be a function')
             if (self.obj_hess is not None
                     and con_hessian is None) or (self.obj_hess is None
                                                  and con_hessian is not None):


### PR DESCRIPTION
Removes use of `scipy.optimize.optimize.MemoizeJac` because it is not publicly exposed by recent versions of `scipy`. See https://github.com/mechmotum/cyipopt/issues/160 for more details. This is done by dropping support for passing `jac=True` in the scipy interface.

Testing: [The jax-scipy example was verified to work](https://github.com/mechmotum/cyipopt/blob/master/examples/hs071_scipy_jax.py).