### PR TITLE
Reduce manual  pre-installation requirements via pyproject.toml

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -30,10 +30,6 @@ dependencies:
   * pkg-config [only for Linux and Mac]
   * Ipopt [>= 3.13 on Windows]
   * Python 3.6+
-  * setuptools
-  * cython
-  * numpy
-  * scipy [optional]
 
 The binaries and header files of the Ipopt package can be obtained from
 http://www.coin-or.org/download/binary/Ipopt/. These include a version compiled

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -30,6 +30,10 @@ dependencies:
   * pkg-config [only for Linux and Mac]
   * Ipopt [>= 3.13 on Windows]
   * Python 3.6+
+  * setuptools
+  * cython
+  * numpy
+  * scipy [optional]
 
 The binaries and header files of the Ipopt package can be obtained from
 http://www.coin-or.org/download/binary/Ipopt/. These include a version compiled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython >= 0.26", "numpy >= 1.15",, "setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cython >= 0.26", "numpy >= 1.15",, "setuptools"]
+requires = ["cython >= 0.26", "numpy >= 1.15", "setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["cython >= 0.26", "numpy >= 1.15", "setuptools>=39.0"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cython >= 0.26", "numpy >= 1.15", "setuptools"]
+requires = ["cython >= 0.26", "numpy >= 1.15", "setuptools>=39.0"]


### PR DESCRIPTION
Adds [`pyproject.toml` file to specify the build dependencies for this package](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/). This removes the need to have e.g. `setuptools` before running `pip install cyipopt`.

Docs are updated accordingly.

On a related note, I think it's worth considering removing `requirements.txt` to reduce confusion.