### PR TITLE
Add support for sparse jacobians in the scipy-interface

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -77,6 +77,15 @@ class IpoptProblemWrapper(object):
     con_dims : array_like, optional
         Dimensions p_1, ..., p_m of the m constraint functions
         g_1, ..., g_m : R^n -> R^(p_i).
+    sparse_jacs: array_like, optional
+        If sparse_jacs[i] = True, the i-th constraint's jacobian is sparse. 
+        Otherwise, the i-th constraint jacobian is assumed to be dense.
+    jac_nnz_row: array_like, optional
+        The row indices of the nonzero elements in the stacked
+        constraint jacobian matrix
+    jac_nnz_col: array_like, optional
+        The column indices of the nonzero elements in the stacked
+        constraint jacobian matrix
     """
 
     def __init__(self,

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -20,6 +20,7 @@ else:
     SCIPY_INSTALLED = True
     del scipy
     from scipy.optimize import approx_fprime
+    import scipy.sparse
     try:
         from scipy.optimize import OptimizeResult
     except ImportError:
@@ -31,6 +32,11 @@ else:
     except ImportError:
         # The optimize.optimize namespace is being deprecated
         from scipy.optimize.optimize import MemoizeJac
+    try:
+        from scipy.sparse import coo_array
+    except ImportError:
+        # coo_array was introduced with scipy 1.8
+        from scipy.sparse import coo_matrix as coo_array
 
 import cyipopt
 
@@ -60,13 +66,19 @@ class IpoptProblemWrapper(object):
         Explicitly defined Hessians are not yet supported for this class.
     constraints : {Constraint, dict} or List of {Constraint, dict}, optional
         See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
-        for more information.
+        for more information. Note that the jacobian of each constraint
+        corresponds to the `'jac'` key and must be a callable function 
+        with signature ``jac(x) -> {ndarray, coo_array}``. If the constraint's
+        value of `'jac'` is a boolean and True, the constraint function `fun`
+        is expected to return a tuple `(con_val, con_jac)` consisting of the 
+        evaluated constraint `con_val` and the evaluated jacobian `con_jac`.
     eps : float, optional
         Epsilon used in finite differences.
     con_dims : array_like, optional
         Dimensions p_1, ..., p_m of the m constraint functions
         g_1, ..., g_m : R^n -> R^(p_i).
     """
+
     def __init__(self,
                  fun,
                  args=(),
@@ -76,7 +88,10 @@ class IpoptProblemWrapper(object):
                  hessp=None,
                  constraints=(),
                  eps=1e-8,
-                 con_dims=()):
+                 con_dims=(),
+                 sparse_jacs=(),
+                 jac_nnz_row=(),
+                 jac_nnz_col=()):
         if not SCIPY_INSTALLED:
             msg = 'Install SciPy to use the `IpoptProblemWrapper` class.'
             raise ImportError()
@@ -105,6 +120,8 @@ class IpoptProblemWrapper(object):
         self._constraint_dims = np.asarray(con_dims)
         self._constraint_args = []
         self._constraint_kwargs = []
+        self._constraint_jac_is_sparse = sparse_jacs
+        self._constraint_jacobian_structure = (jac_nnz_row, jac_nnz_col)
         if isinstance(constraints, dict):
             constraints = (constraints, )
         for con in constraints:
@@ -154,11 +171,25 @@ class IpoptProblemWrapper(object):
             con_values.append(fun(x, *args))
         return np.hstack(con_values)
 
+    def jacobianstructure(self):
+        return self._constraint_jacobian_structure
+
     def jacobian(self, x):
-        con_values = []
-        for jac, args in zip(self._constraint_jacs, self._constraint_args):
-            con_values.append(jac(x, *args))
-        return np.vstack(con_values)
+        # convert all dense constraint jacobians to sparse ones
+        jac_values = []
+        for i, (jac, args) in enumerate(zip(self._constraint_jacs, self._constraint_args)):
+            if self._constraint_jac_is_sparse[i]:
+                jac_val = jac(x, *args)
+            else:
+                # convert dense constraint jacobian to sparse one
+                # problem: jac(x, *args) could yield zeros,
+                # so we assume all entries are nonzero
+                dense_jac_val = np.atleast_2d(jac(x, *args))
+                jac_val = scipy.sparse.coo_array(np.ones_like(dense_jac_val))
+                jac_val.data = dense_jac_val.flatten()
+            jac_values.append(jac_val)
+        J = scipy.sparse.vstack(jac_values)
+        return J.data
 
     def hessian(self, x, lagrange, obj_factor):
         H = obj_factor * self.obj_hess(x)  # type: ignore
@@ -185,12 +216,45 @@ def get_bounds(bounds):
         return lb, ub
 
 
+def get_sparse_jacobian_structure(constraints, x0):
+    con_jac_is_sparse = []
+    jacobians = []
+    x0 = np.asarray(x0)
+    if isinstance(constraints, dict):
+        constraints = (constraints, )
+    if len(constraints) == 0:
+        return [], [], []
+    for con in constraints:
+        con_jac = con.get('jac', False)
+        if con_jac:
+            if isinstance(con_jac, bool):
+                _, jac_val = con['fun'](x0, *con.get('args', []))
+            else:
+                jac_val = con_jac(x0, *con.get('args', []))
+            # check if dense or sparse
+            if isinstance(jac_val, coo_array):
+                jacobians.append(jac_val)
+                con_jac_is_sparse.append(True)
+            else:
+                # Creating the coo_array from jac_val would yield to
+                # wrong dimensions if some values in jac_val are zero,
+                # so we assume all values in jac_val are nonzero
+                jacobians.append(coo_array(np.ones_like(np.atleast_2d(jac_val))))
+                con_jac_is_sparse.append(False)
+        else:
+            # we approximate this jacobian later (=dense)
+            con_val = np.atleast_1d(con['fun'](x0, *con.get('args', [])))
+            jacobians.append(coo_array(np.ones((con_val.size, x0.size))))
+            con_jac_is_sparse.append(False)
+    J = scipy.sparse.vstack(jacobians)
+    return con_jac_is_sparse, J.row, J.col
+
 def get_constraint_dimensions(constraints, x0):
     con_dims = []
     if isinstance(constraints, dict):
         constraints = (constraints, )
     for con in constraints:
-        if con.get('jac', False) is True:
+        if con.get('jac', False) == True:
             m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))[0]))
         else:
             m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))))
@@ -265,8 +329,10 @@ def minimize_ipopt(fun,
     _x0 = np.atleast_1d(x0)
 
     lb, ub = get_bounds(bounds)
-    cl, cu = get_constraint_bounds(constraints, x0)
-    con_dims = get_constraint_dimensions(constraints, x0)
+    cl, cu = get_constraint_bounds(constraints, _x0)
+    con_dims = get_constraint_dimensions(constraints, _x0)
+    sparse_jacs, jac_nnz_row, jac_nnz_col = get_sparse_jacobian_structure(
+        constraints, _x0)
 
     problem = IpoptProblemWrapper(fun,
                                   args=args,
@@ -276,7 +342,10 @@ def minimize_ipopt(fun,
                                   hessp=hessp,
                                   constraints=constraints,
                                   eps=1e-8,
-                                  con_dims=con_dims)
+                                  con_dims=con_dims,
+                                  sparse_jacs=sparse_jacs,
+                                  jac_nnz_row=jac_nnz_row,
+                                  jac_nnz_col=jac_nnz_col)
 
     if options is None:
         options = {}

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -249,6 +249,7 @@ def get_sparse_jacobian_structure(constraints, x0):
     J = scipy.sparse.vstack(jacobians)
     return con_jac_is_sparse, J.row, J.col
 
+
 def get_constraint_dimensions(constraints, x0):
     con_dims = []
     if isinstance(constraints, dict):

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -216,7 +216,7 @@ def get_bounds(bounds):
         return lb, ub
 
 
-def get_sparse_jacobian_structure(constraints, x0):
+def _get_sparse_jacobian_structure(constraints, x0):
     con_jac_is_sparse = []
     jacobians = []
     x0 = np.asarray(x0)
@@ -332,7 +332,7 @@ def minimize_ipopt(fun,
     lb, ub = get_bounds(bounds)
     cl, cu = get_constraint_bounds(constraints, _x0)
     con_dims = get_constraint_dimensions(constraints, _x0)
-    sparse_jacs, jac_nnz_row, jac_nnz_col = get_sparse_jacobian_structure(
+    sparse_jacs, jac_nnz_row, jac_nnz_col = _get_sparse_jacobian_structure(
         constraints, _x0)
 
     problem = IpoptProblemWrapper(fun,

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -255,7 +255,7 @@ def get_constraint_dimensions(constraints, x0):
     if isinstance(constraints, dict):
         constraints = (constraints, )
     for con in constraints:
-        if con.get('jac', False) == True:
+        if con.get('jac', False):
             m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))[0]))
         else:
             m = len(np.atleast_1d(con['fun'](x0, *con.get('args', []))))

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -98,6 +98,109 @@ def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy(
 
 
 @pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid of Scipy available")
+def test_minimize_ipopt_sparse_jac_if_scipy():
+    """ `minimize_ipopt` works with objective gradient, and sparse
+        constraint jacobian. Solves
+        Hock & Schittkowski's test problem 71:
+
+        min x0*x3*(x0+x1+x2)+x2
+        s.t. x0**2 + x1**2 + x2**2 + x3**2 - 40  = 0
+                         x0 * x1 * x2 * x3 - 25 >= 0
+                               1 <= x0,x1,x2,x3 <= 5
+    """
+    from scipy.sparse import coo_array
+
+    def obj(x):
+        return x[0] * x[3] * np.sum(x[:3]) + x[2]
+
+    def grad(x):
+        return np.array([
+            x[0] * x[3] + x[3] * np.sum(x[0:3]), x[0] * x[3],
+            x[0] * x[3] + 1.0, x[0] * np.sum(x[0:3])
+        ])
+
+    # Note:
+    # coo_array(dense_jac_val(x)) only works if dense_jac_val(x0)
+    # doesn't contain any zeros for the initial guess x0
+
+    con_eq = {
+        "type": "eq",
+        "fun": lambda x: np.sum(x**2) - 40,
+        "jac": lambda x: coo_array(2 * x)
+    }
+    con_ineq = {
+        "type": "ineq",
+        "fun": lambda x: np.prod(x) - 25,
+        "jac": lambda x: coo_array(np.prod(x) / x),
+    }
+    constrs = (con_eq, con_ineq)
+
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    bnds = [(1, 5) for _ in range(x0.size)]
+
+    res = cyipopt.minimize_ipopt(obj, jac=grad, x0=x0,
+                                 bounds=bnds, constraints=constrs)
+    assert isinstance(res, dict)
+    assert np.isclose(res.get("fun"), 17.01401727277449)
+    assert res.get("status") == 0
+    assert res.get("success") is True
+    expected_res = np.array([0.99999999, 4.74299964, 3.82114998, 1.3794083])
+    np.testing.assert_allclose(res.get("x"), expected_res)
+
+
+@pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid of Scipy available")
+def test_minimize_ipopt_sparse_and_dense_jac_if_scipy():
+    """ `minimize_ipopt` works with objective gradient, and sparse
+        constraint jacobian. Solves
+        Hock & Schittkowski's test problem 71:
+
+        min x0*x3*(x0+x1+x2)+x2
+        s.t. x0**2 + x1**2 + x2**2 + x3**2 - 40  = 0
+                         x0 * x1 * x2 * x3 - 25 >= 0
+                               1 <= x0,x1,x2,x3 <= 5
+    """
+    from scipy.sparse import coo_array
+
+    def obj(x):
+        return x[0] * x[3] * np.sum(x[:3]) + x[2]
+
+    def grad(x):
+        return np.array([
+            x[0] * x[3] + x[3] * np.sum(x[0:3]), x[0] * x[3],
+            x[0] * x[3] + 1.0, x[0] * np.sum(x[0:3])
+        ])
+
+    # Note:
+    # coo_array(dense_jac_val(x)) only works if dense_jac_val(x0)
+    # doesn't contain any zeros for the initial guess x0
+
+    con_eq_dense = {
+        "type": "eq",
+        "fun": lambda x: np.sum(x**2) - 40,
+        "jac": lambda x: 2 * x
+    }
+    con_ineq_sparse = {
+        "type": "ineq",
+        "fun": lambda x: np.prod(x) - 25,
+        "jac": lambda x: coo_array(np.prod(x) / x),
+    }
+    constrs = (con_eq_dense, con_ineq_sparse)
+
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    bnds = [(1, 5) for _ in range(x0.size)]
+
+    res = cyipopt.minimize_ipopt(obj, jac=grad, x0=x0,
+                                 bounds=bnds, constraints=constrs)
+    assert isinstance(res, dict)
+    assert np.isclose(res.get("fun"), 17.01401727277449)
+    assert res.get("status") == 0
+    assert res.get("success") is True
+    expected_res = np.array([0.99999999, 4.74299964, 3.82114998, 1.3794083])
+    np.testing.assert_allclose(res.get("x"), expected_res)
+
+@pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_hs071():
     """ `minimize_ipopt` works with objective gradient and Hessian and 

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -200,6 +200,7 @@ def test_minimize_ipopt_sparse_and_dense_jac_if_scipy():
     expected_res = np.array([0.99999999, 4.74299964, 3.82114998, 1.3794083])
     np.testing.assert_allclose(res.get("x"), expected_res)
 
+
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_hs071():


### PR DESCRIPTION
Closes #98.

This PR adds support for sparse jacobians in the scipy interface.

- The user can pass dense and sparse constraint jacobians and even mix both
- Each provided jacobian is expected to be a function that returns either a `np.ndarray`(dense) or a `scipy.sparse.coo_array` (sparse).
- Under the hood, all jacobians are converted to sparse matrices in the COO format, i.e. [`coo_array`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.coo_array.html#scipy.sparse.coo_array).

PS: After this PR, the three functions `get_constraint_bounds`, `get_constraint_dimensions`, and `get_sparse_jacobian_structure` will be called in order to create the Ipopt NLP problem before the problem is passed to Ipopt. Since each of these functions will evaluate the constraints and jacobians, I think adding a note in the docs makes sense, specifically that the Problem-interface will have better performance for time-critical use cases or for large-scale problems where evaluating the functions is really expensive.