### PR TITLE
Pass args and kwargs to Hessian of objective function

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -119,7 +119,7 @@ class IpoptProblemWrapper(object):
             jac = fun.derivative
         elif not callable(jac):
             raise NotImplementedError(
-                'jac has to be bool or a function (got {!r})'.format(type(jac))
+                f'jac has to be bool or a function (got {type(jac)!r})'
             )
         self.fun = fun
         self.jac = jac
@@ -148,9 +148,8 @@ class IpoptProblemWrapper(object):
                 con_fun = MemoizeJac(con_fun)
                 con_jac = con_fun.derivative
             elif not callable(con_jac):
-                raise NotImplementedError(
-                    'jac of constraints has to be bool or a function (got {!r})'.format(type(con_jac))
-                )
+                msg = f'jac of constraints has to be bool or a function (got {type(con_jac)!r})'
+                raise NotImplementedError(msg)
             if (self.obj_hess is not None
                     and con_hessian is None) or (self.obj_hess is None
                                                  and con_hessian is not None):
@@ -274,7 +273,8 @@ def get_constraint_dimensions(constraints, x0):
 
 
 def get_constraint_bounds(constraints, x0, INF=1e19):
-    TYPE_EQ, TYPE_INEQ = 'eq', 'ineq'
+    TYPE_EQ = 'eq'
+    TYPE_INEQ = 'ineq'
     cl = []
     cu = []
     if isinstance(constraints, dict):
@@ -290,10 +290,9 @@ def get_constraint_bounds(constraints, x0, INF=1e19):
         elif con['type'] == TYPE_INEQ:
             cu.extend(INF * np.ones(m))
         else:
-            msg = "Invalid constraint type: {!r}. Valid types are {}."
-            raise ValueError(
-                msg.format(con['type'], (TYPE_EQ, TYPE_INEQ))
-            )
+            valid_types = TYPE_EQ, TYPE_INEQ
+            msg = f"Invalid constraint type: {con['type']!r}. Valid types are {valid_types}."
+            raise ValueError(msg)
     cl = np.array(cl)
     cu = np.array(cu)
 
@@ -392,8 +391,8 @@ def minimize_ipopt(fun,
         try:
             nlp.add_option(option, value)
         except TypeError as e:
-            msg = 'Invalid option for IPOPT: {0}: {1} (Original message: "{2}")'
-            raise TypeError(msg.format(option, value, e))
+            msg = f'Invalid option for IPOPT: {option}: {value} (Original message: {e!r})'
+            raise TypeError(msg)
 
     x, info = nlp.solve(_x0)
 

--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -198,7 +198,7 @@ class IpoptProblemWrapper(object):
         return np.hstack(jac_values)
 
     def hessian(self, x, lagrange, obj_factor):
-        H = obj_factor * self.obj_hess(x)  # type: ignore
+        H = obj_factor * self.obj_hess(x, *self.args, **self.kwargs)  # type: ignore
         # split the lagrangian multipliers for each constraint hessian
         lagrs = np.split(lagrange, np.cumsum(self._constraint_dims[:-1]))
         for hessian, args, lagr in zip(self._constraint_hessians,

--- a/cyipopt/tests/integration/test_args_kwargs.py
+++ b/cyipopt/tests/integration/test_args_kwargs.py
@@ -11,31 +11,37 @@ import pytest
 import numpy as np
 import cyipopt
 
-def objective_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
+
+def objective_with_args_kwargs(
+    x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg
+):
     "Least squares loss for a linear regression `Y ~ a + b * X`"
     a, b = x
-    return ( (dataY - a * dataX - b)**2 ).mean()
+    return ((dataY - a * dataX - b) ** 2).mean()
+
 
 def jac_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
     # BOTH `dataX` and `dataY` are used!
     a, b = x
-    return np.array([
-        ( 2 * (dataY - a * dataX - b) * -dataX ).mean(),
-        ( 2 * (dataY - a * dataX - b) * -1     ).mean()
-    ])
+    return np.array(
+        [
+            (2 * (dataY - a * dataX - b) * -dataX).mean(),
+            (2 * (dataY - a * dataX - b) * -1).mean(),
+        ]
+    )
 
-def hess_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
+
+def hess_with_args_kwargs(
+    x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg
+):
     # Only `dataX` is used, but `dataY` must be provided as well
     # to be consistent with `objective_with_args_kwargs` and `jac_with_args_kwargs`.
     dataX_mean = dataX.mean()
-    return np.array([
-        [2 * (dataX**2).mean(), 2 * dataX_mean],
-        [2 * dataX_mean, 2.0]
-    ])
+    return np.array([[2 * (dataX**2).mean(), 2 * dataX_mean], [2 * dataX_mean, 2.0]])
+
 
 def test_args_kwargs():
-    """Practical example of when args and kwargs are useful.
-    """
+    """Practical example of when args and kwargs are useful."""
     # 1. Define data points.
     dataX = np.asfarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     dataY = np.asfarray([1, 2, 5, 3, 5, 4, 7, 5, 3, 8])
@@ -43,10 +49,12 @@ def test_args_kwargs():
     # 2. Minimize loss function.
     x0 = np.asfarray([2.0, 4.0])
     res = cyipopt.minimize_ipopt(
-        objective_with_args_kwargs, x0,
-        args=(dataX, dataY), kwargs={'kwarg': 0},
+        objective_with_args_kwargs,
+        x0,
+        args=(dataX, dataY),
+        kwargs={"kwarg": 0},
         jac=jac_with_args_kwargs,
-        hess=hess_with_args_kwargs
+        hess=hess_with_args_kwargs,
     )
     print(res)
 
@@ -58,45 +66,53 @@ def test_args_kwargs():
     np.testing.assert_allclose(res.fun, expected_fun)
     np.testing.assert_allclose(res.x, expected_x)
 
+
 class TestMissingArgsKwargs:
     x0 = np.asfarray([2.0, 4.0])
 
     def test_missing_everything(self):
         with pytest.raises(TypeError):
             cyipopt.minimize_ipopt(
-                objective_with_args_kwargs, self.x0,
+                objective_with_args_kwargs,
+                self.x0,
                 # Missing args AND mandatory kwargs.
                 # args=(dataX, dataY), kwargs={'kwarg': 0},
                 jac=jac_with_args_kwargs,
-                hess=hess_with_args_kwargs
+                hess=hess_with_args_kwargs,
             )
 
     def test_missing_args(self):
         with pytest.raises(TypeError):
             cyipopt.minimize_ipopt(
-                objective_with_args_kwargs, self.x0,
+                objective_with_args_kwargs,
+                self.x0,
                 # Missing args.
-                args=(), kwargs={'kwarg': 0},
+                args=(),
+                kwargs={"kwarg": 0},
                 jac=jac_with_args_kwargs,
-                hess=hess_with_args_kwargs
+                hess=hess_with_args_kwargs,
             )
 
     def test_missing_kwargs(self):
         with pytest.raises(TypeError):
             cyipopt.minimize_ipopt(
-                objective_with_args_kwargs, self.x0,
+                objective_with_args_kwargs,
+                self.x0,
                 # Missing kwargs.
-                args=(2, 3), kwargs={},
+                args=(2, 3),
+                kwargs={},
                 jac=jac_with_args_kwargs,
-                hess=hess_with_args_kwargs
+                hess=hess_with_args_kwargs,
             )
 
     def test_incorrect_number_of_args(self):
         with pytest.raises(TypeError):
             cyipopt.minimize_ipopt(
-                objective_with_args_kwargs, self.x0,
+                objective_with_args_kwargs,
+                self.x0,
                 # Need two args, but passed only one.
-                args=(2, ), kwargs={'kwarg': 0},
+                args=(2,),
+                kwargs={"kwarg": 0},
                 jac=jac_with_args_kwargs,
-                hess=hess_with_args_kwargs
+                hess=hess_with_args_kwargs,
             )

--- a/cyipopt/tests/integration/test_args_kwargs.py
+++ b/cyipopt/tests/integration/test_args_kwargs.py
@@ -1,0 +1,102 @@
+"""Test passing extra arguments (*args and **kwargs) to objective function and its jac and hess.
+
+Here, these extra arguments are NumPy arrays `dataX` and `dataY`
+used to fit a linear regression `Y ~ a + b * X` using least squares.
+
+NOTE: The mandatory `kwarg` keyword argument in functions below exists
+solely to trigger an exception if not passed from `cyipopt.minimize_ipopt`.
+"""
+import pytest
+
+import numpy as np
+import cyipopt
+
+def objective_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
+    "Least squares loss for a linear regression `Y ~ a + b * X`"
+    a, b = x
+    return ( (dataY - a * dataX - b)**2 ).mean()
+
+def jac_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
+    # BOTH `dataX` and `dataY` are used!
+    a, b = x
+    return np.array([
+        ( 2 * (dataY - a * dataX - b) * -dataX ).mean(),
+        ( 2 * (dataY - a * dataX - b) * -1     ).mean()
+    ])
+
+def hess_with_args_kwargs(x: np.ndarray, dataX: np.ndarray, dataY: np.ndarray, *, kwarg):
+    # Only `dataX` is used, but `dataY` must be provided as well
+    # to be consistent with `objective_with_args_kwargs` and `jac_with_args_kwargs`.
+    dataX_mean = dataX.mean()
+    return np.array([
+        [2 * (dataX**2).mean(), 2 * dataX_mean],
+        [2 * dataX_mean, 2.0]
+    ])
+
+def test_args_kwargs():
+    """Practical example of when args and kwargs are useful.
+    """
+    # 1. Define data points.
+    dataX = np.asfarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    dataY = np.asfarray([1, 2, 5, 3, 5, 4, 7, 5, 3, 8])
+
+    # 2. Minimize loss function.
+    x0 = np.asfarray([2.0, 4.0])
+    res = cyipopt.minimize_ipopt(
+        objective_with_args_kwargs, x0,
+        args=(dataX, dataY), kwargs={'kwarg': 0},
+        jac=jac_with_args_kwargs,
+        hess=hess_with_args_kwargs
+    )
+    print(res)
+
+    # 3. Check solution against known values.
+    # Expected values calculated using Mathematica's `NMinimize`.
+    assert res.success is True
+    expected_fun = 2.22181818181818181818181818182
+    expected_x = np.asfarray([0.490909090909090909090909090909, 1.6])
+    np.testing.assert_allclose(res.fun, expected_fun)
+    np.testing.assert_allclose(res.x, expected_x)
+
+class TestMissingArgsKwargs:
+    x0 = np.asfarray([2.0, 4.0])
+
+    def test_missing_everything(self):
+        with pytest.raises(TypeError):
+            cyipopt.minimize_ipopt(
+                objective_with_args_kwargs, self.x0,
+                # Missing args AND mandatory kwargs.
+                # args=(dataX, dataY), kwargs={'kwarg': 0},
+                jac=jac_with_args_kwargs,
+                hess=hess_with_args_kwargs
+            )
+
+    def test_missing_args(self):
+        with pytest.raises(TypeError):
+            cyipopt.minimize_ipopt(
+                objective_with_args_kwargs, self.x0,
+                # Missing args.
+                args=(), kwargs={'kwarg': 0},
+                jac=jac_with_args_kwargs,
+                hess=hess_with_args_kwargs
+            )
+
+    def test_missing_kwargs(self):
+        with pytest.raises(TypeError):
+            cyipopt.minimize_ipopt(
+                objective_with_args_kwargs, self.x0,
+                # Missing kwargs.
+                args=(2, 3), kwargs={},
+                jac=jac_with_args_kwargs,
+                hess=hess_with_args_kwargs
+            )
+
+    def test_incorrect_number_of_args(self):
+        with pytest.raises(TypeError):
+            cyipopt.minimize_ipopt(
+                objective_with_args_kwargs, self.x0,
+                # Need two args, but passed only one.
+                args=(2, ), kwargs={'kwarg': 0},
+                jac=jac_with_args_kwargs,
+                hess=hess_with_args_kwargs
+            )


### PR DESCRIPTION
- Now `args` and `kwargs` are passed to the Hessian of the objective function. This should fix #175.
- Implemented integration tests to ensure that `args` and `kwargs` are passed to the objective, Jacobian and Hessian.
- Also fixed minor typo in `raise ImportError()` without a `msg` and hopefully clarified some error messages.