### PR TITLE
Change conda-build-version to mamba-version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,10 +30,11 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
+        run: mamba install -y -v lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
           python -m pip install .
+          mamba list
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: '3.21.4'
+          mamba-version: '*'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,17 +21,19 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout CyIpopt
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          mamba-version: '*'
+          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
+        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt
-        run: python -m pip install .
+        run: |
+          rm pyproject.toml
+          python -m pip install .
       - name: Test building documentation
         run: cd docs && make clean && make html && cd ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,16 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+        run: mamba install -y -v lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
           python -m pip install .
+          mamba list
       - name: Test with pytest
         run: |
           python -c "import cyipopt"
-          mamba install -y -q pytest>=3.3.2
+          mamba install -y -v cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
           pytest
-          mamba install -y -q scipy>=0.19.1
+          mamba install -y -v cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2 scipy>=0.19.1
           pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,22 +22,24 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout CyIpopt
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          mamba-version: '*'
+          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
-        run: python -m pip install .
+        run: |
+          rm pyproject.toml
+          python -m pip install .
       - name: Test with pytest
-        run:
+        run: |
           python -c "import cyipopt"
-          conda install -y -q pytest>=3.3.2
+          mamba install -y -q pytest>=3.3.2
           pytest
-          conda install -y -q scipy>=0.19.1
+          mamba install -y -q scipy>=0.19.1
           pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: '3.21.4'
+          mamba-version: '*'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,22 +29,24 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout CyIpopt
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          mamba-version: '*'
+          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
-        run: python -m pip install .
+        run: |
+          rm pyproject.toml
+          python -m pip install .
       - name: Test with pytest
-        run:
+        run: |
           python -c "import cyipopt"
-          conda install -y -q pytest>=3.3.2
+          mamba install -y -q pytest>=3.3.2
           pytest
-          conda install -y -q scipy>=0.19.1
+          mamba install -y -q scipy>=0.19.1
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          conda-build-version: '3.21.4'
+          mamba-version: '*'
       - name: Install basic dependencies
         run: conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,17 +36,29 @@ jobs:
           activate-environment: test-environment
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+        run: |
+          conda install -n base conda-libmamba-solver
+          conda config --set solver libmamba
+          conda install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
           python -m pip install .
+          conda list
       - name: Test with pytest
         run: |
           python -c "import cyipopt"
-          mamba install -y -q pytest>=3.3.2
+          conda remove lapack
+          conda install -q -y cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
+          conda list
           pytest
-          mamba install -y -q scipy>=0.19.1
+      - name: Test with pytest and scipy, new ipopt
+        # cyipopt can build with these dependencies, but it seems impossible to
+        # also install scipy into these environments likely due to SciPy and
+        # Ipopt needed different libfortrans.
+        if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
+        run: |
+          conda install -q -y -c conda-forge cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2 scipy>=0.19.0
+          conda list
           pytest

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -76,7 +76,7 @@ def test_minimize_ipopt_nojac_constraints_if_scipy():
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_jac_and_hessians_constraints_if_scipy(
 ):
-    """`minimize_ipopt` works with objective gradient and Hessian 
+    """`minimize_ipopt` works with objective gradient and Hessian
        and constraint jacobians and Hessians."""
     from scipy.optimize import rosen, rosen_der, rosen_hess
     x0 = [0.0, 0.0]
@@ -109,7 +109,10 @@ def test_minimize_ipopt_sparse_jac_if_scipy():
                          x0 * x1 * x2 * x3 - 25 >= 0
                                1 <= x0,x1,x2,x3 <= 5
     """
-    from scipy.sparse import coo_array
+    try:
+        from scipy.sparse import coo_array
+    except ImportError:
+        from scipy.sparse import coo_matrix as coo_array
 
     def obj(x):
         return x[0] * x[3] * np.sum(x[:3]) + x[2]
@@ -161,7 +164,10 @@ def test_minimize_ipopt_sparse_and_dense_jac_if_scipy():
                          x0 * x1 * x2 * x3 - 25 >= 0
                                1 <= x0,x1,x2,x3 <= 5
     """
-    from scipy.sparse import coo_array
+    try:
+        from scipy.sparse import coo_array
+    except ImportError:
+        from scipy.sparse import coo_matrix as coo_array
 
     def obj(x):
         return x[0] * x[3] * np.sum(x[:3]) + x[2]
@@ -204,10 +210,10 @@ def test_minimize_ipopt_sparse_and_dense_jac_if_scipy():
 @pytest.mark.skipif("scipy" not in sys.modules,
                     reason="Test only valid if Scipy available.")
 def test_minimize_ipopt_hs071():
-    """ `minimize_ipopt` works with objective gradient and Hessian and 
+    """ `minimize_ipopt` works with objective gradient and Hessian and
          constraint jacobians and Hessians.
 
-        The objective and the constraints functions return a tuple containing 
+        The objective and the constraints functions return a tuple containing
         the function value and the evaluated gradient or jacobian. Solves
         Hock & Schittkowski's test problem 71:
 


### PR DESCRIPTION
This PR attempts to fix #177 by replacing `conda-build-version` in `conda-incubator/setup-miniconda` step of all jobs in all GitHub Actions workflows with `mamba-version`, as per https://github.com/conda-incubator/setup-miniconda/issues/116.