### PR TITLE
Use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython >= 0.26", "numpy >= 1.15", "setuptools>=39.0"]
+requires = ["cython >= 0.26", "oldest-supported-numpy", "setuptools>=39.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
As per https://numpy.org/devdocs/dev/depending_on_numpy.html#build-time-dependency