### PR TITLE
Don’t use deprecated/removed np.float alias

### DIFF
--- a/examples/lasso.py
+++ b/examples/lasso.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
     #
     n = 100
     e = 1
-    beta = np.array((0, 0, 2, -4, 0, 0, -1, 3), dtype=np.float).reshape((-1, 1))
+    beta = np.array((0, 0, 2, -4, 0, 0, -1, 3), dtype=np.float64).reshape((-1, 1))
 
     #
     # Set the random number generator seed.


### PR DESCRIPTION
In examples/lasso.py, change np.float (which was deprecated in numpy 1.20 and removed in numpy 1.24) to np.float64.