### PR TITLE
DOC: minimize_ipopt: add documentation

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -324,11 +324,77 @@ def minimize_ipopt(fun,
                    callback=None,
                    options=None):
     """
-    Minimize a function using ipopt. The call signature is exactly like for
-    ``scipy.optimize.mimize``. In options, all options are directly passed to
-    ipopt. Check [http://www.coin-or.org/Ipopt/documentation/node39.html] for
-    details. The options ``disp`` and ``maxiter`` are automatically mapped to
-    their ipopt-equivalents ``print_level`` and ``max_iter``.
+    Minimization using Ipopt with an interface like `scipy.optimize.minimize`.
+
+    This function can be used to solve general nonlinear programming problems
+    of the form:
+
+    .. math::
+
+       \min_ {x \in R^n} f(x)
+
+    subject to
+
+    .. math::
+
+       g_L \leq g(x) \leq g_U
+
+       x_L \leq  x  \leq x_U
+
+    Where :math:`x` are the optimization variables, :math:`f(x)` is the
+    objective function, :math:`g(x)` are the general nonlinear constraints,
+    and :math:`x_L` and :math:`x_U` are the upper and lower bounds
+    (respectively) on the decision variables. The constraints, :math:`g(x)`,
+    have lower and upper bounds :math:`g_L` and :math:`g_U`. Note that equality
+    constraints can be specified by setting :math:`g^i_L = g^i_U`.
+
+    Parameters
+    ----------
+    fun : callable
+        The objective function to be minimized: ``fun(x, *args, **kwargs) ->
+        float``.
+    x0 : array-like, shape(n, )
+        Initial guess. Array of real elements of shape (n,),
+        where ``n`` is the number of independent variables.
+    args : tuple, optional
+        Extra arguments passed to the objective function and its
+        derivatives (``fun``, ``jac``, and ``hess``).
+    kwargs : dictionary, optional
+        Extra keyword arguments passed to the objective function and its
+        derivatives (``fun``, ``jac``, ``hess``).
+    method : str, optional
+        This parameter is ignored. `minimize_ipopt` always uses Ipopt; use
+        `scipy.optimize.minimize` directly for other methods.
+    jac : callable, optional
+        The Jacobian of the objective function: ``jac(x, *args, **kwargs) ->
+        ndarray, shape(n, )``. If ``None``, SciPy's ``approx_fprime`` is used.
+    hess : callable, optional
+        If ``None``, the Hessian is computed using IPOPT's numerical methods.
+        Explicitly defined Hessians are not yet supported via this interface.
+    hessp : callable, optional
+        If ``None``, the Hessian is computed using IPOPT's numerical methods.
+        Explicitly defined Hessians are not yet supported via this interface.
+    bounds :  sequence, shape(n, ), optional
+        Sequence of ``(min, max)`` pairs for each element in `x`. Use ``None``
+        to specify no bound.
+    constraints : {Constraint, dict}, optional
+        See `scipy.optimize.minimize` for more information. Note that the
+        Jacobian of each constraint corresponds to the ``'jac'`` key and must
+        be a callable function with signature
+        ``jac(x) -> {ndarray, coo_array}``. If the constraint's
+        value of ``'jac'`` is ``True``, the constraint function ``fun`` must
+        return a tuple ``(con_val, con_jac)`` consisting of the evaluated
+        constraint ``con_val`` and the evaluated Jacobian ``con_jac``.
+    tol : float, optional (default=1e-8)
+        The desired relative convergence tolerance, passed as an option to
+        Ipopt. See [https://coin-or.github.io/Ipopt/OPTIONS.html] for details.
+    options : dict, optional
+        A dictionary of solver options. The options ``disp`` and ``maxiter``
+        are automatically mapped to their Ipopt equivalents ``print_level``
+        and ``max_iter``. All other options are passed directly to Ipopt. See
+        [https://coin-or.github.io/Ipopt/OPTIONS.html] for details.
+    callback : callable, optional
+        This parameter is ignored.
     """
     if not SCIPY_INSTALLED:
         msg = 'Install SciPy to use the `minimize_ipopt` function.'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -255,3 +256,11 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+# -----------------------------------------------------------------------------
+# Intersphinx configuration
+# -----------------------------------------------------------------------------
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/dev', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+}


### PR DESCRIPTION
Thanks for maintaining cyipopt! 

I'm a SciPy maintainer, and we've discussed the possibility of adding `method='ipopt'` to `scipy.optimize.minimize` (with cyipopt as an optional dependency due to the license incompatibility). For now, though, we thought we'd try to help improve the compatibility between `cyipopt.minimize_ipopt` and `scipy.optimize.minimize` interfaces.

To start, this PR begins to add formal documentation to `cyipopt.minimize_ipopt`.

Please let me know if you're interested in continued contributions. In this PR, for example, I could also try to add:
- More complete documentation of `constraints`
- References (e.g. Ipopt documentation)
- Examples

As follow-up work, ideas include:
- Support for the `method` parameter (i.e. allowing use of all `scipy.optimize.minimize` methods)
- Support for SciPy's new-style constraints ([`Bounds`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.Bounds.html), [`NonlinearConstraint`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.NonlinearConstraint.html#scipy.optimize.NonlinearConstraint))
- Trying to improve numerical derivatives. (as-is, I'm not having very good luck unless analytical derivatives are defined.)

Please let me know if you'd like me to file issues for problems I've noticed. For instance, I'm on Windows and after creating a fresh environment, `conda install -c conda-forge cyipopt jax` fails due to an environment conflict. 