### PR TITLE
MAINT: minimize_ipopt: fix late binding bug when defining constraint Jacobians

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -157,8 +157,11 @@ class IpoptProblemWrapper(object):
             con_hessian = con.get('hess', None)
             con_kwargs = con.get('kwargs', {})
             if con_jac is None:
-                con_jac = lambda x0, *args, **kwargs: approx_fprime(
-                    x0, con_fun, eps, *args, **kwargs)
+                # beware of late binding!
+                def con_jac(x, *args, con_fun=con_fun, **kwargs):
+                    def wrapped(x):
+                        return con_fun(x, *args, **kwargs)
+                    return approx_fprime(x, wrapped, eps)
             elif con_jac is True:
                 con_fun = MemoizeJac(con_fun)
                 con_jac = con_fun.derivative


### PR DESCRIPTION
As reported in https://github.com/mechmotum/cyipopt/pull/194#discussion_r1155423756, `minimize_ipopt` fails on the [`scipy.optimize.minimize`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) example with three constraints. This is due to a [late binding gotcha](https://docs.python-guide.org/writing/gotchas/#late-binding-closures) when the constraint Jacobians are defined in a loop. This fixes that bug and demonstrates that the example problem is solved successfully after the fix.

<details>
Try me before and after.

```python3
from cyipopt import minimize_ipopt

fun = lambda x: (x[0] - 1)**2 + (x[1] - 2.5)**2
cons = ({'type': 'ineq', 'fun': lambda x:  x[0] - 2 * x[1] + 2},
        {'type': 'ineq', 'fun': lambda x: -x[0] - 2 * x[1] + 6},
        {'type': 'ineq', 'fun': lambda x: -x[0] + 2 * x[1] + 2})
bnds = ((0, None), (0, None))

res = minimize_ipopt(fun, (2, 0), bounds=bnds, constraints=cons)
```

</details>

Incidentally, this also fixes an unreported bug: `kwargs` was being passed to `approx_fprime`. but `approx_fprime` doesn't accept `kwargs`. Another instance of this bug is fixed in https://github.com/mechmotum/cyipopt/pull/200/files#r1198383113.