### PR TITLE
Pin Cython<3 until compatibility can be fixed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.26
+cython>=0.26,<3
 ipopt>=3.12
 numpy>=1.15
 pkg-config>=0.29.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.extension import Extension
 # install requirements before import
 from setuptools import dist
 SETUP_REQUIRES = [
-    "cython >= 0.26",
+    "cython >= 0.26,<3",
     "numpy >= 1.15",
 ]
 dist.Distribution().fetch_build_eggs(SETUP_REQUIRES)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ AUTHOR = "Jason K. Moore"
 EMAIL = "moorepants@gmail.com"
 URL = "https://github.com/mechmotum/cyipopt"
 INSTALL_REQUIRES = [
-    "cython>=0.26",
     "numpy>=1.15",
     "setuptools>=39.0",
 ]


### PR DESCRIPTION
Works around, but does not fix, https://github.com/mechmotum/cyipopt/issues/211.

In addition to upper-bounding the version of Cython, this also drops Cython from `install_requires`, since it doesn’t appear to be a real runtime dependency.