### PR TITLE
Use Cython <3 legacy behavior.

### DIFF
--- a/cyipopt/cython/ipopt.pxd
+++ b/cyipopt/cython/ipopt.pxd
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# cython: language_level=2, legacy_implicit_noexcept=True
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.
 
@@ -12,7 +13,7 @@ License: EPL 2.0
 cdef extern from "IpoptConfig.h":
 
     int IPOPT_VERSION_MAJOR
-    
+
     int IPOPT_VERSION_MINOR
 
     int IPOPT_VERSION_RELEASE

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# cython: language_level=2, legacy_implicit_noexcept=True
 """
 cyipopt: Python wrapper for the Ipopt optimization package, written in Cython.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.26,<3
+cython>=0.26
 ipopt>=3.12
 numpy>=1.15
 pkg-config>=0.29.2

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools.extension import Extension
 # install requirements before import
 from setuptools import dist
 SETUP_REQUIRES = [
-    "cython >= 0.26,<3",
+    "cython >= 0.26",
     "numpy >= 1.15",
 ]
 dist.Distribution().fetch_build_eggs(SETUP_REQUIRES)
@@ -48,7 +48,7 @@ AUTHOR = "Jason K. Moore"
 EMAIL = "moorepants@gmail.com"
 URL = "https://github.com/mechmotum/cyipopt"
 INSTALL_REQUIRES = [
-    "cython >= 0.26,<3",
+    "cython >= 0.26",
     "numpy>=1.15",
     "setuptools>=39.0",
 ]


### PR DESCRIPTION
Cython 3 causes build errors due to the new requirement of the noexcept clause. The language_level compiler directive is also set to Python 3 by default. This commit restores the legacy behavior so the builds work with Cython <3 and >=3. We will need to make proper fixes, as Cython will probably drop the legacy functionality at some point.