### PR TITLE
Now picks up Windows Ipopt binary files that are adjacent to setup.py (restores regression)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           channels: conda-forge
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
-        run: mamba install -y -v lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
+        run: mamba install -y -v lapack "libblas=*=*netlib" "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 --file docs/requirements.txt
       - name: Install CyIpopt
         run: |
           rm pyproject.toml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.29.*"
       - name: Install CyIpopt
         run: |
-          echo "IPOPTWINDIR=USECONDAFORGE" >> $GITHUB_ENV
+          echo "IPOPTWINDIR=USECONDAFORGEIPOPT" >> $GITHUB_ENV
           rm pyproject.toml
           python -m pip install .
           mamba list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" cython<3 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython+=0.26,<3"
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y cython<3 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
+          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "pytest>=3.3.2" "cython>=0.26,<3"
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge cython<3 "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
+          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2" "cython>=0.26,<3"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        ipopt-version: ['3.12', '3.13', '3.14']
+        ipopt-version: ['3.12', '3.13', '3.14.11']
         exclude:
           - os: windows-latest
             ipopt-version: '3.12'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "cython<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+          mamba install -q -y lapack "libblas=*=*netlib" cython<3 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y "cython<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
+          mamba install -q -y cython<3 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "cython<3" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
+          mamba install -q -y -c conda-forge cython<3 "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython>=0.26,<3"
+          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.2*"
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "pytest>=3.3.2" "cython>=0.26,<3"
+          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "pytest>=3.3.2" "cython=0.2*"
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2" "cython>=0.26,<3"
+          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2" "cython=0.2*"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+          mamba install -q -y lapack "libblas=*=*netlib" "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y cython>=0.26 "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
+          mamba install -q -y "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "cython>=0.26" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
+          mamba install -q -y -c conda-forge "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install basic dependencies
         run: |
           mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.29.*"
+      - run: echo "IPOPTWINDIR=USECONDAFORGEIPOPT" >> $GITHUB_ENV
       - name: Install CyIpopt
         run: |
-          echo "IPOPTWINDIR=USECONDAFORGEIPOPT" >> $GITHUB_ENV
           rm pyproject.toml
           python -m pip install .
           mamba list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        ipopt-version: ['3.12', '3.13', '3.14.11']
+        ipopt-version: ['3.12', '3.13', '3.14']
         exclude:
           - os: windows-latest
             ipopt-version: '3.12'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
+          mamba install -q -y lapack "libblas=*=*netlib" "cython<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
+          mamba install -q -y "cython<3" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.15 pkg-config>=0.29.2 setuptools>=39.0 pytest>=3.3.2
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "cython>=0.26,<3" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
+          mamba install -q -y -c conda-forge "cython<3" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.2*"
+          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.29.*"
       - name: Install CyIpopt
         run: |
           rm pyproject.toml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -c "import cyipopt"
           mamba remove lapack
-          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "pytest>=3.3.2" "cython=0.2*"
+          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "pytest>=3.3.2" "cython=0.29.*"
           mamba list
           pytest
       - name: Test with pytest and scipy, new ipopt
@@ -54,6 +54,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2" "cython=0.2*"
+          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "scipy=1.9.*" "pytest>=3.3.2" "cython=0.29.*"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython+=0.26,<3"
+          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython>=0.26,<3"
       - name: Install CyIpopt
         run: |
           rm pyproject.toml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
           mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.15" "pkg-config>=0.29.2" "setuptools>=39.0" "cython=0.29.*"
       - name: Install CyIpopt
         run: |
+          echo "IPOPTWINDIR=USECONDAFORGE" >> $GITHUB_ENV
           rm pyproject.toml
           python -m pip install .
           mamba list

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,25 @@
+name: windows
+
+on: [push, pull_request]
+
+# cancels prior builds for this workflow when new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Manually install on Windows with Ipopt binaries
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: python -m pip install numpy "cython<3" setuptools
+      - run: wget "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.3/Ipopt-3.13.3-win64-msvs2019-md.zip"
+      - run: unzip Ipopt-3.13.3-win64-msvs2019-md.zip
+      - run: mv Ipopt-3.13.3-win64-msvs2019-md/* .
+      - run: python setup.py install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install numpy "cython<3" setuptools
-      - run: wget "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.3/Ipopt-3.13.3-win64-msvs2019-md.zip"
-      - run: unzip Ipopt-3.13.3-win64-msvs2019-md.zip
+      - run: Invoke-WebRequest -Uri "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.3/Ipopt-3.13.3-win64-msvs2019-md.zip"
+      - run: 7z x Ipopt-3.13.3-win64-msvs2019-md.zip
       - run: mv Ipopt-3.13.3-win64-msvs2019-md/* .
       - run: python setup.py install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,3 +23,4 @@ jobs:
       - run: 7z x Ipopt-3.13.3-win64-msvs2019-md.zip
       - run: mv Ipopt-3.13.3-win64-msvs2019-md/* .
       - run: python setup.py install
+      - run: python examples/hs071.py

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install numpy "cython<3" setuptools
-      - run: Invoke-WebRequest -Uri "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.3/Ipopt-3.13.3-win64-msvs2019-md.zip"
+      - run: Invoke-WebRequest -Uri "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.3/Ipopt-3.13.3-win64-msvs2019-md.zip" -OutFile "Ipopt-3.13.3-win64-msvs2019-md.zip"
       - run: 7z x Ipopt-3.13.3-win64-msvs2019-md.zip
       - run: mv Ipopt-3.13.3-win64-msvs2019-md/* .
       - run: python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -185,13 +185,17 @@ if __name__ == "__main__":
     # environment variable is set to USECONDAFORGEIPOPT then this setup will be
     # run.
     if sys.platform == "win32" and ipoptdir == "USECONDAFORGEIPOPT":
+        print('Using Conda Forge Ipopt on Windows.')
         ext_module_data = handle_ext_modules_win_32_conda_forge_ipopt()
     elif sys.platform == "win32" and ipoptdir:
+        print('Using custom Ipopt in custom directory on Windows.')
         ext_module_data = handle_ext_modules_win_32_other_ipopt()
     elif sys.platform == "win32":
+        print('Using Ipopt adjacent to setup.py on Windows.')
         ipopdir = os.path.abspath(os.path.dirname(__file__))
         ext_module_data = handle_ext_modules_win_32_other_ipopt()
     else:
+        print('Using Ipopt found with pkg-config.')
         ext_module_data = handle_ext_modules_general_os()
     EXT_MODULES, DATA_FILES, include_package_data = ext_module_data
     # NOTE : The `name` kwarg here is the distribution name, i.e. the name that

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,9 @@ if __name__ == "__main__":
         ext_module_data = handle_ext_modules_win_32_conda_forge_ipopt()
     elif sys.platform == "win32" and ipoptdir:
         ext_module_data = handle_ext_modules_win_32_other_ipopt()
+    elif sys.platform == "win32":
+        ipopdir = os.path.abspath(os.path.dirname(__file__))
+        ext_module_data = handle_ext_modules_win_32_other_ipopt()
     else:
         ext_module_data = handle_ext_modules_general_os()
     EXT_MODULES, DATA_FILES, include_package_data = ext_module_data

--- a/setup.py
+++ b/setup.py
@@ -188,11 +188,12 @@ if __name__ == "__main__":
         print('Using Conda Forge Ipopt on Windows.')
         ext_module_data = handle_ext_modules_win_32_conda_forge_ipopt()
     elif sys.platform == "win32" and ipoptdir:
-        print('Using custom Ipopt in custom directory on Windows.')
+        print('Using Ipopt in {} directory on Windows.'.format(ipoptdir))
         ext_module_data = handle_ext_modules_win_32_other_ipopt()
-    elif sys.platform == "win32":
-        print('Using Ipopt adjacent to setup.py on Windows.')
-        ipopdir = os.path.abspath(os.path.dirname(__file__))
+    elif sys.platform == "win32" and not ipoptdir:
+        ipoptdir = os.path.abspath(os.path.dirname(__file__))
+        msg = 'Using Ipopt adjacent to setup.py in {} on Windows.'
+        print(msg.format(ipoptdir))
         ext_module_data = handle_ext_modules_win_32_other_ipopt()
     else:
         print('Using Ipopt found with pkg-config.')


### PR DESCRIPTION
At some point we disabled the appveyor windows CI run that would download an official Ipopt windows release and test building against that. In our documentation it implies that you can take the contents of that Ipopt zip file and place them adjacent to the setup.py file and they'd get picked up. 

https://cyipopt.readthedocs.io/en/stable/install.html#from-source-on-windows says: "After Ipopt is extracted, the bin, lib and include folders should be in the root cyipopt directory, i.e. adjacent to the setup.py file." but it seems like we removed the support for this and it isn't present here:

https://github.com/mechmotum/cyipopt/blob/master/setup.py#L187

This adds back the functionality as well as a Github action to test that it works.