### PR TITLE
Enable support for cython 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython>=0.29.28,<3", "oldest-supported-numpy","setuptools>=44.1.1"]
+requires = ["cython>=0.29.28", "oldest-supported-numpy","setuptools>=44.1.1"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools.extension import Extension
 # install requirements before import
 from setuptools import dist
 SETUP_REQUIRES = [
-    "cython>=0.29.28,<3",
+    "cython>=0.29.28",
     "numpy>=1.21.5",
     "setuptools>=44.1.1",
 ]


### PR DESCRIPTION
This is an attempt to fix #211:

- All callbacks are now marked `noexpect` with exceptions being handled (stored) internally
- A large `try` / `expect` block is used in the callbacks, where code outside of the blocks should not throw (only stack allocations)
- The large Jacobian / Hessian callbacks have been split up into value / structure callbacks
- Cython restriction to <3 was removed