### PR TITLE
ENH: expose 'eps' option for finite difference step size

### DIFF
--- a/cyipopt/tests/unit/test_scipy_ipopt_from_scipy.py
+++ b/cyipopt/tests/unit/test_scipy_ipopt_from_scipy.py
@@ -1125,7 +1125,13 @@ def test_gh11649():
     ref = minimize(fun=obj, x0=x0, method='slsqp',
                    bounds=bnds, constraints=nlcs)
     assert ref.success
-    assert res.fun <= ref.fun
+    assert res.fun <= ref.fun  # Ipopt legitimately does better than slsqp here
+
+    # If we give SLSQP a good guess, it agrees with Ipopt
+    ref2 = minimize(fun=obj, x0=res.x, method='slsqp',
+                   bounds=bnds, constraints=nlcs)
+    assert ref2.success
+    assert_allclose(ref2.fun, res.fun)
 
 
 @pytest.mark.skipif("scipy" not in sys.modules,

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -577,6 +577,8 @@ def test_minimize_late_binding_bug():
     np.testing.assert_allclose(res.fun, ref.fun)
 
 
+@pytest.mark.skipif("scipy" not in sys.modules,
+                    reason="Test only valid if Scipy available.")
 def test_gh115_eps_option():
     # gh-115 requested that the `eps` argument be exposed as an option. Verify
     # that it is working as advertised (at least for the objective function).

--- a/cyipopt/tests/unit/test_scipy_optional.py
+++ b/cyipopt/tests/unit/test_scipy_optional.py
@@ -575,3 +575,23 @@ def test_minimize_late_binding_bug():
     assert res.success
     np.testing.assert_allclose(res.x, ref.x)
     np.testing.assert_allclose(res.fun, ref.fun)
+
+
+def test_gh115_eps_option():
+    # gh-115 requested that the `eps` argument be exposed as an option. Verify
+    # that it is working as advertised (at least for the objective function).
+    def f(x):
+        if f.x is None:
+            f.x = x
+        elif f.dx is None:
+            f.dx = x - f.x
+        return x ** 2
+
+    f.x, f.dx = None, None
+    cyipopt.minimize_ipopt(f, x0=0)
+    np.testing.assert_equal(f.dx, 1e-8)
+
+    f.x, f.dx = None, None
+    eps = 1e-9
+    cyipopt.minimize_ipopt(f, x0=0, options={'eps': eps})
+    np.testing.assert_equal(f.dx, eps)


### PR DESCRIPTION
closes gh-115, which requested that `eps`, the finite difference step size, be exposed as an option. 