### PR TITLE
Add examples/ and docs/requirements.txt to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include cyipopt *.py *.pyx *.pxd
 recursive-include ipopt *.py
 recursive-include tests *.py
 recursive-include docs Makefile *.bat *.rst *.py
+recursive-include examples *.py
 exclude cyipopt/tests/unit/test_scipy_ipopt_from_scipy.py
 prune include*
 prune lib*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include README.rst
 recursive-include cyipopt *.py *.pyx *.pxd
 recursive-include ipopt *.py
 recursive-include tests *.py
-recursive-include docs Makefile *.bat *.rst *.py
+recursive-include docs Makefile *.bat *.rst *.py requirements.txt
 recursive-include examples *.py
 exclude cyipopt/tests/unit/test_scipy_ipopt_from_scipy.py
 prune include*


### PR DESCRIPTION
https://github.com/mechmotum/cyipopt/issues/237#issuecomment-1826793291

This PR seems to be effective for `python3 setup.py sdist` but not for `python3 -m build`.