### PR TITLE
Fix #239

### DIFF
--- a/cyipopt/scipy_interface.py
+++ b/cyipopt/scipy_interface.py
@@ -596,10 +596,8 @@ def minimize_ipopt(fun,
     # Rename some default scipy options
     replace_option(options, b'disp', b'print_level')
     replace_option(options, b'maxiter', b'max_iter')
-    if getattr(options, 'print_level', False) is True:
-        options[b'print_level'] = 1
-    else:
-        options[b'print_level'] = 0
+    options[b'print_level'] = int(options.get(b'print_level', 5))
+
     if b'tol' not in options:
         options[b'tol'] = tol or 1e-8
     if b'mu_strategy' not in options:


### PR DESCRIPTION
Hotfix for `print_level` to allow integer other than 0 or 1. 
Bools are also converted this way.