### PR TITLE
Add clarity to jacobian/hessianstructure methods

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -253,15 +253,18 @@ methods should return the non-zero values of the respective matrices as
 flattened arrays. The hessian should return a flattened lower triangular
 matrix.
 
-The Jacobian and Hessian can be dense or sparse. If sparse, you must also
-define:
+The Jacobian and Hessian can be dense or sparse. If sparse,
+:func:`cyipopt.Problem.jacobian` and :func:`cyipopt.Problem.hessian` methods
+should return only the non-zero values of the respective matrices and you must
+also define:
 
 - :func:`cyipopt.Problem.jacobianstructure`
 - :func:`cyipopt.Problem.hessianstructure`
 
-which should return a tuple of indices that indicate the location of the
-non-zero values of the Jacobian and Hessian matrices, respectively. If not
-defined then these matrices are assumed to be dense.
+which should return a tuple of indices (row indices, column indices) that
+indicate the location of the non-zero values of the Jacobian and Hessian
+matrices, respectively. If not defined then these matrices are assumed to be
+dense.
 
 The :func:`cyipopt.Problem.intermediate` method is called every Ipopt iteration
 algorithm and can be used to perform any needed computation at each iteration.


### PR DESCRIPTION
This is an edit to the tutorial documentation.

Original tutorial is not entirely clear on what the jacobian/hessian jacobian/hessianstructure methods should return when providing them as sparse matrices.

I'm not sure if this is the best way to add this information. The structure of the method returns is shown in the example below it, but, as a user, it took me some time to see how best to structure the returns (I also mistakenly tried to use a scipy sparse matrix structure as a return at one point).