### PR TITLE
Add install instructions for HSL on windows 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.21.5" "pkg-config>=0.29.2" "setuptools>=44.1.1" "scipy>1.8.0" "pytest>=6.2.5" "cython=0.29.*"
+          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.21.5" "pkg-config>=0.29.2" "setuptools>=44.1.1" "scipy>1.8.0,<1.13" "pytest>=6.2.5" "cython=0.29.*"
           mamba list
           pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,6 @@ jobs:
         # Ipopt needed different libfortrans.
         if: (matrix.ipopt-version != '3.12' && matrix.python-version != '3.11') || (matrix.ipopt-version != '3.12' && matrix.python-version != '3.10' && matrix.os != 'macos-latest')
         run: |
-          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.21.5" "pkg-config>=0.29.2" "setuptools>=44.1.1" "scipy>1.8.0,<1.13" "pytest>=6.2.5" "cython=0.29.*"
+          mamba install -q -y -c conda-forge "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.21.5" "pkg-config>=0.29.2" "setuptools>=44.1.1" "scipy>1.8.0,<1.13.0" "pytest>=6.2.5" "cython=0.29.*"
           mamba list
           pytest

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -336,6 +336,9 @@ descriptions::
 Conda Forge binaries with HSL
 -----------------------------
 
+On Linux
+-----------------------------
+
 It is possible to use the HSL linear solvers with cyipopt installed via Conda
 Forge. To do so, first download the HSL source code tarball. The following
 explanation uses ``coinhsl-2014.01.10.tar.gz`` with conda installed on Ubuntu
@@ -414,3 +417,39 @@ name must be specified because the default name ipopt looks for is
 ``libhsl.so``. Identify the shared library installed on your system and make
 sure the name provided for the ``hsllib`` option matches. For example, on macOS
 you may need ``problem.add_option('hsllib', 'libcoinhsl.dylib')``.
+
+
+On Windows
+-----------------------------
+On windows it could be possible to use HSL solvers with Conda version of cyipopt, 
+first install cyipopt via standard call::
+
+   $ conda create -n hsl-test -c conda-forge cyipopt
+   $ conda activate hsl-test
+
+Download HSL linear solvers, e.g. ``ma27, ma57, ma86`` from its
+official website <http://www.hsl.rl.ac.uk/ipopt/>. Download the ``windows`` binaries option, 
+in this example, we are using "CoinHSL Archive 2023.11.17 (windows binaries)" option. 
+This will download a zipped file that contains a folder ``bin``. Copy all the DLL files from
+that folder into your conda env\Library\bin folder 
+(This folder should also contain the an ipopt dll file installed with cyipopt (in our case it was called ``ipopt-3.dll``)::
+
+   <conda_location>\envs\<env_name>\Library\bin
+
+Once the DLL files are placed you should be able to access the HSL solvers using solver options, in pyomo::
+
+   solver = pyo.SolverFactory("cyipopt")
+   solver.config.options["linear_solver"] = "ma27"   
+
+If all works well, you should see the following when setting ``tee=True``::
+
+   ******************************************************************************
+   This program contains Ipopt, a library for large-scale nonlinear optimization.
+   Ipopt is released as open source code under the Eclipse Public License (EPL).
+            For more information visit https://github.com/coin-or/Ipopt
+   ******************************************************************************
+
+   This is Ipopt version 3.14.16, running with linear solver ma27.
+
+This was tested on Windows 11 x64 with Ipopt version 3.14.16. 
+

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -436,10 +436,9 @@ that folder into your conda env\Library\bin folder
 
    <conda_location>\envs\<env_name>\Library\bin
 
-Once the DLL files are placed you should be able to access the HSL solvers using solver options, in pyomo::
+Once the DLL files are placed you should be able to access the HSL solvers using solver options::
 
-   solver = pyo.SolverFactory("cyipopt")
-   solver.config.options["linear_solver"] = "ma27"   
+   problem.add_option('linear_solver', 'ma57')  
 
 If all works well, you should see the following when setting ``tee=True``::
 


### PR DESCRIPTION
This adds simple instructions on how to add HSL binaries to windows conda install of cyipopt.  - tested only on my machine, so hopefully it works for others. 