### PR TITLE
Added application return status Maximum_WallTime_Exceeded, new in Ipopt 3.14.

### DIFF
--- a/cyipopt/cython/ipopt.pxd
+++ b/cyipopt/cython/ipopt.pxd
@@ -12,7 +12,7 @@ License: EPL 2.0
 cdef extern from "IpoptConfig.h":
 
     int IPOPT_VERSION_MAJOR
-    
+
     int IPOPT_VERSION_MINOR
 
     int IPOPT_VERSION_RELEASE
@@ -109,6 +109,7 @@ cdef extern from "IpStdCInterface.h":
         Restoration_Failed=-2
         Error_In_Step_Computation=-3
         Maximum_CpuTime_Exceeded=-4
+        Maximum_WallTime_Exceeded=-5  # Added in Ipopt 3.14
         Not_Enough_Degrees_Of_Freedom=-10
         Invalid_Problem_Definition=-11
         Invalid_Option=-12

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -108,6 +108,7 @@ STATUS_MESSAGES = {
     Error_In_Step_Computation: (b"An unrecoverable error occurred while Ipopt "
                                 b"tried to compute the search direction."),
     Maximum_CpuTime_Exceeded: b"Maximum CPU time exceeded.",
+    Maximum_WallTime_Exceeded: b"Maximum wallclock time exceeded.",
     Not_Enough_Degrees_Of_Freedom: b"Problem has too few degrees of freedom.",
     Invalid_Problem_Definition: b"Invalid problem definition.",
     Invalid_Option: b"Invalid option encountered.",


### PR DESCRIPTION
This is a new status message added in Ipopt 3.14. Fixes #259.

TODO

- [ ] Make sure this compiles with Ipopt < 3.14.