### PR TITLE
Remove deprecated oldest-supported-numpy from pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython>=0.29.28", "oldest-supported-numpy","setuptools>=44.1.1"]
+requires = ["cython>=0.29.28", "numpy","setuptools>=44.1.1"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.extension import Extension
 from setuptools import dist
 SETUP_REQUIRES = [
     "cython>=0.29.28",
-    "numpy>=1.21.5",
+    "numpy",
     "setuptools>=44.1.1",
 ]
 dist.Distribution().fetch_build_eggs(SETUP_REQUIRES)


### PR DESCRIPTION
See: https://github.com/scipy/oldest-supported-numpy?tab=readme-ov-file#deprecation-notice-for-numpy-20

The oldest-supported-numpy package is no longer needed. We remove any pinning on NumPy for the build requirements so it can be built with NumPy 1.* or NumPy 2.*.