### PR TITLE
Removed the netlib build and simply build with the os preferred lapack.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,18 +35,16 @@ jobs:
           miniforge-variant: Mambaforge
       - name: Install basic dependencies against generic blas/lapack
         run: |
-          mamba install -q -y lapack "libblas=*=*netlib" "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.25" "pkg-config>=0.29.2" "setuptools>=44.1.1" "cython>=0.29.28"
+          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.25" "pkg-config>=0.29.2" "setuptools>=44.1.1" "cython>=0.29.28" "pytest>=6.2.5"
       - run: echo "IPOPTWINDIR=USECONDAFORGEIPOPT" >> $GITHUB_ENV
-      - name: Install CyIpopt
+      - name: Install cyipopt
         run: |
           rm pyproject.toml
-          python -m pip install .
+          python -m pip install --no-deps --no-build-isolation .
           mamba list
-      - name: Test with pytest using OS specific blas/lapack
+      - name: Test with pytest and run examples
         run: |
           python -c "import cyipopt"
-          mamba remove lapack
-          mamba install -q -y "ipopt=${{ matrix.ipopt-version }}" "numpy>=1.25" "pkg-config>=0.29.2" "setuptools>=44.1.1" "pytest>=6.2.5" "cython=0.29.*"
           mamba list
           pytest
           python examples/hs071.py


### PR DESCRIPTION
I had things set up to build against netlib blas/lapack and then to install conda's os preferred blas/lapack implementation to run the tests, but it seems that the netlib version was hanging around and things weren't working with the macosx builds failing with current conda forge packages. I don't actually need to do this netlib/no netlib test, as it is done downstream in the cyipopt-feedstock for conda forge.