### PR TITLE
Changes to improve exception handling

### DIFF
--- a/cyipopt/tests/unit/test_deriv_errors.py
+++ b/cyipopt/tests/unit/test_deriv_errors.py
@@ -1,13 +1,7 @@
 import numpy as np
-
-import cyipopt
-
 import pytest
 
-
-pre_3_14_13 = (
-    cyipopt.IPOPT_VERSION < (3, 14, 13)
-)
+import cyipopt
 
 
 def full_indices(shape):
@@ -83,43 +77,26 @@ def problem_for_instance(instance):
                            cu=instance.cu)
 
 
+def ensure_status_after_solve(nlp, x0, exception, msg, status):
+    try:
+        nlp.solve(x0)
+    except exception as e:
+        assert nlp.info["status"] == status
+        print(f"{str(e) = }")
+        assert str(e) == msg
+    else:
+        assert False, f"Expected {exception = } not raised"
+
+
 def test_solve_sparse(hs071_sparse_instance):
     instance = hs071_sparse_instance
     problem = problem_for_instance(instance)
 
     x, info = problem.solve(instance.x0)
 
-    assert info['status'] == 0
+    assert info["status"] == 0
 
 
-def ensure_solve_status(instance, status):
-    problem = problem_for_instance(instance)
-
-    problem.add_option('max_iter', 50)
-    x, info = problem.solve(instance.x0)
-
-    assert info['status'] == status
-
-
-def ensure_invalid_option(instance):
-    # -12: Invalid option
-    # Thrown in invalid Hessian because "hessian_approximation"
-    # is not chosen as "limited-memory"
-    ensure_solve_status(instance, -12)
-
-
-def ensure_invalid_number(instance):
-    # -13: Invalid Number Detected
-    ensure_solve_status(instance, -13)
-
-
-def ensure_unrecoverable_exception(instance):
-    # -100: Unrecoverable Exception
-    # *Should* be returned from errors in initialization
-    ensure_solve_status(instance, -100)
-
-
-@pytest.mark.skipif(pre_3_14_13, reason="Not caught in Ipopt < (3,14,13)")
 def test_solve_neg_jac(hs071_sparse_instance):
     n = hs071_sparse_instance.n
     m = hs071_sparse_instance.m
@@ -131,18 +108,15 @@ def test_solve_neg_jac(hs071_sparse_instance):
         return r, c
 
     problem_definition.jacobianstructure = jacobianstructure
+    msg = "All row indices must be non-negative and less than m"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
-    ensure_unrecoverable_exception(hs071_sparse_instance)
 
-
-@pytest.mark.skipif(pre_3_14_13, reason="Not caught in Ipopt < (3,14,13)")
 def test_solve_large_jac(hs071_sparse_instance):
     n = hs071_sparse_instance.n
     m = hs071_sparse_instance.m
     problem_definition = hs071_sparse_instance.problem_definition
-
-    import logging
-    logging.basicConfig(level=logging.DEBUG)
 
     def jacobianstructure():
         r = np.full((m*n,), fill_value=(m + n + 100), dtype=int)
@@ -150,23 +124,23 @@ def test_solve_large_jac(hs071_sparse_instance):
         return r, c
 
     problem_definition.jacobianstructure = jacobianstructure
+    msg = "All row indices must be non-negative and less than m"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
-    ensure_unrecoverable_exception(hs071_sparse_instance)
 
 
-@pytest.mark.skipif(pre_3_14_13, reason="Not caught in Ipopt < (3,14,13)")
 def test_solve_wrong_jac_structure_size(hs071_sparse_instance):
     n = hs071_sparse_instance.n
     m = hs071_sparse_instance.m
 
     problem_definition = hs071_sparse_instance.problem_definition
+    problem_definition.jacobianstructure = full_indices((m + 1, n + 1))
+    msg = "All row indices must be non-negative and less than m"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
-    problem_definition.jacobianstructure = full_indices((m+1, n+1))
 
-    ensure_unrecoverable_exception(hs071_sparse_instance)
-
-
-@pytest.mark.skipif(pre_3_14_13, reason="Not caught in Ipopt < (3,14,13)")
 def test_solve_wrong_jac_value_size(hs071_sparse_instance):
     n = hs071_sparse_instance.n
     m = hs071_sparse_instance.m
@@ -177,16 +151,18 @@ def test_solve_wrong_jac_value_size(hs071_sparse_instance):
         return np.zeros((m*n + 10,))
 
     problem_definition.jacobian = jacobian
-
-    ensure_invalid_number(hs071_sparse_instance)
+    nlp = problem_for_instance(hs071_sparse_instance)
+    msg = "Invalid number of indices returned from jacobian"
+    ensure_status_after_solve(nlp, hs071_sparse_instance.x0, ValueError, msg, 5)
 
 
 def test_solve_triu_hess(hs071_sparse_instance):
     n = hs071_sparse_instance.n
     problem_definition = hs071_sparse_instance.problem_definition
     problem_definition.hessianstructure = lambda: np.triu_indices(n)
-
-    ensure_invalid_option(hs071_sparse_instance)
+    msg = "Indices are not lower triangular in hessianstructure"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
 
 def test_solve_neg_hess_entries(hs071_sparse_instance):
@@ -200,8 +176,9 @@ def test_solve_neg_hess_entries(hs071_sparse_instance):
         return rneg, cneg
 
     problem_definition.hessianstructure = hessianstructure
-
-    ensure_invalid_option(hs071_sparse_instance)
+    msg = "All column indices must be non-negative and less than n"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
 
 def test_solve_large_hess_entries(hs071_sparse_instance):
@@ -215,8 +192,9 @@ def test_solve_large_hess_entries(hs071_sparse_instance):
         return rlarge, clarge
 
     problem_definition.hessianstructure = hessianstructure
-
-    ensure_invalid_option(hs071_sparse_instance)
+    msg = "All column indices must be non-negative and less than n"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
 
 def test_solve_wrong_hess_struct_size(hs071_sparse_instance):
@@ -227,8 +205,9 @@ def test_solve_wrong_hess_struct_size(hs071_sparse_instance):
         return np.tril_indices(n + 10)
 
     problem_definition.hessianstructure = hessianstructure
-
-    ensure_invalid_option(hs071_sparse_instance)
+    msg = "All column indices must be non-negative and less than n"
+    with pytest.raises(ValueError, match=msg):
+        nlp = problem_for_instance(hs071_sparse_instance)
 
 
 def test_solve_wrong_hess_value_size(hs071_sparse_instance):
@@ -239,5 +218,7 @@ def test_solve_wrong_hess_value_size(hs071_sparse_instance):
         return np.zeros((n*n + 10,))
 
     problem_definition.hessian = hessian
-
-    ensure_invalid_number(hs071_sparse_instance)
+    nlp = problem_for_instance(hs071_sparse_instance)
+    msg = ("Number of indices returned from hessianstructure and number of values "
+           "returned from hessian are not equal")
+    ensure_status_after_solve(nlp, hs071_sparse_instance.x0, ValueError, msg, 5)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths =
     cyipopt/tests
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Addresses issue #286 

## The Problem

Currently, there are many situations in which cyipopt produces predictable but cryptic errors in response to user input errors. Some examples:

- If some of the indices returned by jacobianstructure are negative, one would expect an error message such as

  ```text
  ValueError: All jacobian row indices must be non-negative and less than m
  ```

  Instead, Ipopt halts with status code -100 (Unrecoverable Exception), without any indication that this issue is an error in the indices.

- If the hessian callback raises an exception, one would expect the exception to be raised eventually for the user to see. That doesn't happen, and instead the hessian is not calculated, and typically the Ipopt iteration will never converge.  This bug is really insidious, because the user won't know that there's an exception in their code.

- If a user specifies hessian indices that are not lower triangular, Ipopt exits with status code -12, Invalid Option, because it concludes that no hessian is provides, and expects the `hessian_approximation` option to be "limited-memory". It would be much better of course to get an error message:
  
  ```text
  ValueError: Indices are not lower triangular in hessianstructure
  ```

## The Causes

There are multiple issues:

1. The jacobianstructure and hessianstructure user callbacks are called at problem instantiation only to get the length of the index arrays, with no error checking. Error checking is deferred until the Ipopt solver is called, and the error checking is done in the callbacks. That's a particularly problematic design choice, because an exception should not be raised in the callbacks. When an error is detected, the callbacks return `False`, which in turn leads Ipopt to return a failure status code. A quick fix would be to raise an exception in the callbacks, which would be caught in the try-except block. That's awkward, but actually works on MacOS, but causes a segfault on Linux, because it leaves the index arrays uninitialized.

2. There are bugs in the `hessian_cb` function. For one, the `user_data` pointer is cast as `self = <object>user_data` instead of `self = <Problem>user_data`. That changes how Cython name mangles variables, and the result is that the `self.__exception = sys.exc_info()` doesn't actually pass the exception back to the class, and so an exception in the user hessian callback never gets re-raised. Further, there's a missing `return True` that prevents the intermediate callback from stopping Ipopt execution.

## Proposed Solution

My proposed solution moves all the index checking into the `Problem.__init__` method, so that all errors are caught at problem instantiation. This effectively moves all the code from `jacobian_struct_cb` and `hessian_struct_cb` into the constructor, and also simplifies `jacobian_cb` and ``hessian_cb`. All errors in the indices raise `ValueError` exceptions, with richer messages than the current log messages to provide better feedback to the user.

I've also fixed the logic error that silenced all exceptions in the user hessian callback.

In order to allow unit testing of these changes, I added a feature that should be useful to the user. I've added a `Problem.info` attribute, which holds the info dict return in a `problem.solve(x0)`, so that if an exception is re-raised after the call to the Ipopt solver, it can be caught by the unit tests (or the user!), and both the return status and the state of the solver can be examined. Adding `Problem.info` does not break the current API, and could actually be viewed as a positive feature to help users debug their code. In not desired as a feature, it could be changed to `Problem.__info`.

I've also fixed a few typos here and there.

## Readiness of the PR

This PR is not to master but to a feature branch, improve-exception-handling, so that if the PR is accepted, some polishing can be done before merging to main. I have some additional tests that aren't quite ready, and minor changes to the docs would be required as well. If you'd prefer a different approach, let me know.

The current PR does pass all the CI tests I believe. I've modifed the `test_deriv_errors.py` test to reflect my changes. An added bonus is that because all the indices are properly tested and an exception is raised if there's an error before the call the Ipopt solver,  it's no longer necessary to distinguish pre and post Ipopt v3.14.13, and that is reflected in the tests.