### PR TITLE
Add cibuildwheel CI workflow for cross-platform binary wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,100 @@
+name: Build wheels
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create dummy ipopt.pc for sdist metadata generation
+        run: |
+          sudo mkdir -p /usr/local/lib/pkgconfig
+          sudo tee /usr/local/lib/pkgconfig/ipopt.pc > /dev/null <<'PKGCONFIG'
+          prefix=/usr/local
+          libdir=${prefix}/lib
+          includedir=${prefix}/include/coin-or
+
+          Name: ipopt
+          Description: dummy for sdist
+          Version: 3.14.11
+          Libs: -L${libdir} -lipopt
+          Cflags: -I${includedir}
+          PKGCONFIG
+
+      - name: Build sdist
+        run: PKG_CONFIG_PATH=/usr/local/lib/pkgconfig pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux-x86_64
+            runs-on: ubuntu-latest
+            cibw-archs: x86_64
+          - os: linux-aarch64
+            runs-on: ubuntu-24.04-arm
+            cibw-archs: aarch64
+          - os: macos-arm64
+            runs-on: macos-latest
+            cibw-archs: arm64
+          - os: windows-amd64
+            runs-on: windows-latest
+            cibw-archs: AMD64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw-archs }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build_wheels_pyodide:
+    name: Wheels (pyodide)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4
+        env:
+          CIBW_PLATFORM: pyodide
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-pyodide
+          path: wheelhouse/*.whl
+
+  upload_artifacts:
+    name: Collect all artifacts
+    needs: [build_sdist, build_wheels, build_wheels_pyodide]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: all-dist
+          path: dist/

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,38 @@ for linux/aarch64 platforms. Built wheels appear at the folder the command was e
 .. warning::
     Docker supports emulating non-native platforms to e.g. produce ARM binaries from an AMD64 host. However this can be quite slow (~1h for our case).
 
+Using in Pyodide (browser/WASM)
+================================
+
+cyipopt can run in the browser via `Pyodide <https://pyodide.org>`_, with Ipopt
+compiled to WebAssembly. Pre-built wheels are available from
+`GitHub releases <https://github.com/mechmotum/cyipopt/releases>`_.
+
+Install with micropip in a Pyodide environment:
+
+.. code-block:: python
+
+   import micropip
+   await micropip.install(
+       "https://github.com/mechmotum/cyipopt/releases/download/VERSION/cyipopt-VERSION-cp312-cp312-pyodide_2024_0_wasm32.whl"
+   )
+
+Then use it normally:
+
+.. code-block:: python
+
+   import numpy as np
+   from cyipopt import minimize_ipopt
+   from scipy.optimize import rosen, rosen_der
+
+   x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
+   res = minimize_ipopt(rosen, x0, jac=rosen_der)
+   print(res.x)
+
+**Full example**: see the `grecov calculator <https://louisabraham.github.io/grecov/>`_
+for a working web app that uses cyipopt in Pyodide to solve nonlinear optimization
+problems entirely in the browser.
+
 License
 =======
 

--- a/build_manylinux_wheels.sh
+++ b/build_manylinux_wheels.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Builds manylinux cyipopt wheels with Ipopt 3.14.11 based on MUMPS 5.5.1, and OpenBLAS 0.3.15
+# NOTE: For automated CI builds, see .github/workflows/build_wheels.yml which uses cibuildwheel.
 set -eu  # Stop script if a line fails
 TAG=${1}
 echo "Building cyipopt with tag $TAG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,35 @@
 [build-system]
-requires = ["cython>=0.29.37", "numpy>=1.25","setuptools>=68.1.2"]
+requires = ["cython>=0.29.37", "numpy>=2.0","setuptools>=68.1.2"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-* cp313-*"
+skip = "*-win32 *-manylinux_i686 *-musllinux_*"
+build-frontend = "pip"
+test-requires = "numpy"
+test-command = "python {project}/tools/test_wheel.py"
+
+[tool.cibuildwheel.linux]
+before-all = "bash {project}/tools/build_ipopt_manylinux.sh && bash {project}/tools/append_bundled_licenses.sh"
+environment = { PKG_CONFIG_PATH="/usr/local/lib/pkgconfig", LD_LIBRARY_PATH="/usr/local/lib" }
+
+[tool.cibuildwheel.macos]
+before-all = "bash {project}/tools/install_ipopt_conda.sh"
+before-build = "pip install --no-binary numpy 'numpy>=2.0' cython setuptools"
+build-frontend = { name = "pip", args = ["--no-build-isolation"] }
+test-requires = ""
+before-test = "pip install --no-binary numpy 'numpy>=2.0'"
+environment = { PKG_CONFIG_PATH="/tmp/ipopt_conda/lib/pkgconfig", DYLD_LIBRARY_PATH="/tmp/ipopt_conda/lib" }
+repair-wheel-command = "DYLD_LIBRARY_PATH=/tmp/ipopt_conda/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.windows]
+before-all = "curl -L -o ipopt.zip https://github.com/coin-or/Ipopt/releases/download/releases%2F3.14.11/Ipopt-3.14.11-win64-msvs2019-md.zip && 7z x ipopt.zip -oC:/ipopt"
+before-build = "pip install delvewheel"
+environment = { IPOPTWINDIR="C:/ipopt/Ipopt-3.14.11-win64-msvs2019-md" }
+repair-wheel-command = "delvewheel repair --add-path C:/ipopt/Ipopt-3.14.11-win64-msvs2019-md/bin -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.pyodide]
+before-all = "bash {project}/tools/setup_ipopt_pyodide.sh"
+before-build = "emcc -c /tmp/ipopt_wasm/lib/wasm32_bridges.c -o /tmp/ipopt_wasm/lib/wasm32_bridges.o && python3 {project}/tools/strip_wasm_features.py /tmp/ipopt_wasm/lib/lib*.a"
+build-frontend = "build"
+environment = { PKG_CONFIG_PATH="/tmp/ipopt_wasm/lib/pkgconfig", LDFLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -Wl,--no-fatal-warnings" }

--- a/tools/append_bundled_licenses.sh
+++ b/tools/append_bundled_licenses.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Appends bundled library licenses to the LICENSE file for binary wheel distributions.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+echo "------------------------------" >> LICENSE
+echo "This binary distribution of cyipopt also bundles the following software" >> LICENSE
+for bundled_license in licenses_manylinux_bundled_libraries/*.txt; do
+    cat "$bundled_license" >> LICENSE
+done

--- a/tools/build_ipopt_manylinux.sh
+++ b/tools/build_ipopt_manylinux.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Compiles Ipopt and its dependencies (MUMPS + OpenBLAS) for manylinux wheel builds.
+# This script is intended to run inside a manylinux_2_28 container.
+set -eu
+
+# Install efficient BLAS & LAPACK library
+yum install -y openblas-devel
+
+pushd /tmp
+
+# MUMPS (Linear solver used by Ipopt)
+git clone https://github.com/coin-or-tools/ThirdParty-Mumps --depth=1 --branch releases/3.0.4
+pushd ThirdParty-Mumps
+sh get.Mumps
+./configure --with-lapack="-L/usr/include/openblas -lopenblas"
+make
+make install
+popd
+
+# Ipopt (The solver itself)
+git clone https://github.com/coin-or/Ipopt --depth=1 --branch releases/3.14.11
+pushd Ipopt
+./configure --with-lapack="-L/usr/include/openblas -lopenblas"
+make
+make install
+popd
+
+popd
+
+ldconfig

--- a/tools/install_ipopt_conda.sh
+++ b/tools/install_ipopt_conda.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Installs Ipopt via conda-forge (Miniforge) for macOS wheel builds.
+# Installs to /tmp/ipopt_conda so pkg-config and delocate can find the libraries.
+set -eu
+
+INSTALL_DIR="/tmp/ipopt_conda"
+
+# Download and install Miniforge
+curl -L -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
+bash /tmp/miniforge.sh -b -p "$INSTALL_DIR"
+
+# Install ipopt and pkg-config
+"$INSTALL_DIR/bin/conda" install -y -p "$INSTALL_DIR" ipopt pkg-config

--- a/tools/setup_ipopt_pyodide.sh
+++ b/tools/setup_ipopt_pyodide.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Downloads pre-built wasm32 Ipopt libraries and headers for Pyodide builds.
+# Libraries from https://louisabraham.github.io/ipopt-wasm/
+set -eu
+
+INSTALL_DIR="/tmp/ipopt_wasm"
+IPOPT_VERSION="3.14.19"
+BASE_URL="https://louisabraham.github.io/ipopt-wasm"
+IPOPT_RAW="https://raw.githubusercontent.com/coin-or/Ipopt/releases/$IPOPT_VERSION"
+
+mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/include/coin-or" "$INSTALL_DIR/lib/pkgconfig"
+
+# Download pre-built wasm32 static libraries
+for lib in libipopt.a libmumps.a liblapack.a libflangrt.a; do
+    curl -sfL "$BASE_URL/$lib" -o "$INSTALL_DIR/lib/$lib"
+done
+
+# Download wasm32 ABI bridges (compiled during build via before-build)
+curl -sfL "$BASE_URL/wasm32_bridges.c" -o "$INSTALL_DIR/lib/wasm32_bridges.c"
+
+# Download Ipopt C interface headers
+for header in IpStdCInterface.h IpReturnCodes.h IpReturnCodes_inc.h; do
+    curl -sfL "$IPOPT_RAW/src/Interfaces/$header" -o "$INSTALL_DIR/include/coin-or/$header"
+done
+for header in IpoptConfig.h IpTypes.h config_ipopt_default.h; do
+    curl -sfL "$IPOPT_RAW/src/Common/$header" -o "$INSTALL_DIR/include/coin-or/$header"
+done
+
+# Create pkg-config file
+cat > "$INSTALL_DIR/lib/pkgconfig/ipopt.pc" << EOF
+prefix=$INSTALL_DIR
+libdir=\${prefix}/lib
+includedir=\${prefix}/include/coin-or
+
+Name: ipopt
+Description: Ipopt (wasm32, pre-built from ipopt-wasm)
+Version: $IPOPT_VERSION
+Libs: -L\${libdir} \${libdir}/wasm32_bridges.o -lipopt -lmumps -llapack -lflangrt
+Cflags: -I\${includedir}
+EOF
+
+echo "Ipopt wasm32 libraries installed to $INSTALL_DIR"

--- a/tools/strip_wasm_features.py
+++ b/tools/strip_wasm_features.py
@@ -1,0 +1,213 @@
+"""Strip target_features custom sections from wasm objects inside .a archives.
+
+This is needed when libraries are compiled with a newer Emscripten (e.g. 5.0.2)
+but linked in an older Emscripten environment (e.g. 3.1.58 used by Pyodide).
+The newer compiler embeds feature flags (bulk-memory-opt, call-indirect-overlong)
+that the older wasm-opt doesn't recognize.
+
+Approach: rewrite each .a archive, processing each wasm .o member to remove
+the target_features custom section. Uses pure Python archive parsing to avoid
+ar compatibility issues across platforms.
+"""
+
+import sys
+import os
+
+
+# Features not supported by older wasm-opt (Emscripten 3.1.58)
+FEATURES_TO_STRIP = {b'bulk-memory-opt', b'call-indirect-overlong'}
+
+
+def read_leb128(data, pos):
+    """Read an unsigned LEB128 value."""
+    value = 0
+    shift = 0
+    while pos < len(data):
+        byte = data[pos]
+        pos += 1
+        value |= (byte & 0x7f) << shift
+        shift += 7
+        if not (byte & 0x80):
+            break
+    return value, pos
+
+
+def write_leb128(value):
+    """Encode an unsigned LEB128 value."""
+    result = bytearray()
+    while True:
+        byte = value & 0x7f
+        value >>= 7
+        if value:
+            byte |= 0x80
+        result.append(byte)
+        if not value:
+            break
+    return result
+
+
+def filter_target_features(section_payload: bytes) -> bytes | None:
+    """Remove unsupported features from a target_features section payload.
+
+    Returns filtered payload, or None if section should be kept as-is.
+    The payload starts AFTER the section name.
+    """
+    pos = 0
+    count, pos = read_leb128(section_payload, pos)
+
+    features = []
+    for _ in range(count):
+        prefix = section_payload[pos:pos + 1]
+        pos += 1
+        name_len, pos = read_leb128(section_payload, pos)
+        name = section_payload[pos:pos + name_len]
+        pos += name_len
+        features.append((prefix, name))
+
+    filtered = [(p, n) for p, n in features if n not in FEATURES_TO_STRIP]
+    if len(filtered) == len(features):
+        return None  # Nothing changed
+
+    # Rebuild payload
+    result = bytearray()
+    result.extend(write_leb128(len(filtered)))
+    for prefix, name in filtered:
+        result.extend(prefix)
+        result.extend(write_leb128(len(name)))
+        result.extend(name)
+    return bytes(result)
+
+
+def patch_target_features(wasm_bytes: bytes) -> bytes:
+    """Remove unsupported features from target_features in a wasm binary."""
+    if len(wasm_bytes) < 8 or wasm_bytes[:4] != b'\x00asm':
+        return wasm_bytes
+
+    result = bytearray(wasm_bytes[:8])  # magic + version
+    pos = 8
+    changed = False
+
+    while pos < len(wasm_bytes):
+        section_id = wasm_bytes[pos]
+        pos += 1
+
+        size, pos = read_leb128(wasm_bytes, pos)
+        section_data = wasm_bytes[pos:pos + size]
+        pos += size
+
+        # Custom section (id=0): check if it's target_features
+        if section_id == 0 and len(section_data) > 0:
+            name_len, name_start = read_leb128(section_data, 0)
+            if name_start + name_len <= len(section_data):
+                name = section_data[name_start:name_start + name_len]
+                if name == b'target_features':
+                    payload_start = name_start + name_len
+                    payload = section_data[payload_start:]
+                    filtered = filter_target_features(payload)
+                    if filtered is not None:
+                        changed = True
+                        # Rebuild section data: name_len + name + filtered_payload
+                        new_section_data = (
+                            section_data[:payload_start] + filtered
+                        )
+                        result.append(section_id)
+                        result.extend(write_leb128(len(new_section_data)))
+                        result.extend(new_section_data)
+                        continue
+
+        # Write section back unchanged
+        result.append(section_id)
+        result.extend(write_leb128(size))
+        result.extend(section_data)
+
+    return bytes(result) if changed else wasm_bytes
+
+
+def process_archive(archive_path: str) -> None:
+    """Strip target_features from all wasm objects in a Unix ar archive."""
+    with open(archive_path, 'rb') as f:
+        data = f.read()
+
+    if not data.startswith(b'!<arch>\n'):
+        print(f"Not an ar archive: {archive_path}")
+        return
+
+    # Parse ar archive and rewrite members
+    pos = 8  # Skip magic
+    members = []
+    modified_count = 0
+
+    # Read string table for long names (if present)
+    string_table = b''
+
+    while pos < len(data):
+        # Each member header is 60 bytes
+        if pos + 60 > len(data):
+            break
+
+        header = data[pos:pos + 60]
+        name_raw = header[0:16]
+        size_str = header[48:58].strip()
+        magic = header[58:60]
+
+        if magic != b'`\n':
+            break
+
+        size = int(size_str)
+        member_data = data[pos + 60:pos + 60 + size]
+
+        # Determine member name
+        name = name_raw.rstrip()
+        if name == b'//' or name == b'//':
+            # String table for long names
+            string_table = member_data
+            members.append((header, member_data, False))
+        elif name == b'/' or name == b'/':
+            # Symbol table
+            members.append((header, member_data, False))
+        else:
+            # Regular member - check if it's a wasm object
+            is_wasm = len(member_data) >= 4 and member_data[:4] == b'\x00asm'
+            if is_wasm:
+                stripped = patch_target_features(member_data)
+                if stripped is not member_data:
+                    modified_count += 1
+                    # Update size in header if changed
+                    new_size = len(stripped)
+                    new_header = (
+                        header[:48]
+                        + f'{new_size:<10d}'.encode()
+                        + header[58:60]
+                    )
+                    members.append((new_header, stripped, True))
+                else:
+                    members.append((header, member_data, False))
+            else:
+                members.append((header, member_data, False))
+
+        # Move to next member (padded to 2-byte boundary)
+        pos += 60 + size
+        if pos % 2 != 0:
+            pos += 1
+
+    if modified_count == 0:
+        print(f"No features to strip in {archive_path}")
+        return
+
+    # Rebuild archive
+    output = bytearray(b'!<arch>\n')
+    for header, member_data, was_modified in members:
+        output.extend(header)
+        output.extend(member_data)
+        if len(member_data) % 2 != 0:
+            output.append(0x0a)  # Pad to even
+
+    with open(archive_path, 'wb') as f:
+        f.write(output)
+
+    print(f"Patched target_features in {modified_count} objects in {archive_path}")
+
+
+if __name__ == '__main__':
+    for path in sys.argv[1:]:
+        process_archive(path)

--- a/tools/test_wheel.py
+++ b/tools/test_wheel.py
@@ -1,0 +1,80 @@
+"""Smoke test for wheel builds: imports cyipopt and solves HS071."""
+import numpy as np
+import cyipopt
+
+
+class HS071:
+
+    def objective(self, x):
+        return x[0] * x[3] * np.sum(x[0:3]) + x[2]
+
+    def gradient(self, x):
+        return np.array([
+            x[0] * x[3] + x[3] * np.sum(x[0:3]),
+            x[0] * x[3],
+            x[0] * x[3] + 1.0,
+            x[0] * np.sum(x[0:3])
+        ])
+
+    def constraints(self, x):
+        return np.array((np.prod(x), np.dot(x, x)))
+
+    def jacobian(self, x):
+        return np.concatenate((np.prod(x) / x, 2 * x))
+
+    def hessianstructure(self):
+        return np.nonzero(np.tril(np.ones((4, 4))))
+
+    def hessian(self, x, lagrange, obj_factor):
+        H = obj_factor * np.array((
+            (2 * x[3], 0, 0, 0),
+            (x[3], 0, 0, 0),
+            (x[3], 0, 0, 0),
+            (2 * x[0] + x[1] + x[2], x[0], x[0], 0)))
+        H += lagrange[0] * np.array((
+            (0, 0, 0, 0),
+            (x[2] * x[3], 0, 0, 0),
+            (x[1] * x[3], x[0] * x[3], 0, 0),
+            (x[1] * x[2], x[0] * x[2], x[0] * x[1], 0)))
+        H += lagrange[1] * 2 * np.eye(4)
+        row, col = self.hessianstructure()
+        return H[row, col]
+
+
+def main():
+    x0 = [1.0, 5.0, 5.0, 1.0]
+    lb = [1.0, 1.0, 1.0, 1.0]
+    ub = [5.0, 5.0, 5.0, 5.0]
+    cl = [25.0, 40.0]
+    cu = [2.0e19, 40.0]
+
+    nlp = cyipopt.Problem(
+        n=len(x0),
+        m=len(cl),
+        problem_obj=HS071(),
+        lb=lb,
+        ub=ub,
+        cl=cl,
+        cu=cu,
+    )
+    nlp.add_option('mu_strategy', 'adaptive')
+    nlp.add_option('tol', 1e-7)
+    nlp.add_option('print_level', 0)
+
+    x, info = nlp.solve(x0)
+
+    # Known optimal solution for HS071
+    x_expected = np.array([1.0, 4.74299963, 3.82114998, 1.37940829])
+    obj_expected = 17.014017145179164
+
+    assert info['status'] == 0, f"Solver did not converge: status={info['status']}"
+    assert np.allclose(x, x_expected, atol=1e-4), f"Unexpected solution: {x}"
+    assert np.isclose(info['obj_val'], obj_expected, atol=1e-4), (
+        f"Unexpected objective: {info['obj_val']}"
+    )
+
+    print(f"cyipopt {cyipopt.__version__} — wheel smoke test passed")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow using cibuildwheel v3.4 to build binary wheels for **Linux** (x86_64, aarch64), **macOS** (arm64), **Windows** (AMD64), and **Pyodide** (wasm32)
- Platform-specific Ipopt installation: compile from source (Linux), conda-forge (macOS), pre-built COIN-OR binary (Windows), pre-built wasm32 static libs (Pyodide)
- Wheel repair via auditwheel (Linux), delocate (macOS), delvewheel (Windows)
- Smoke test on all platforms solving HS071 with convergence assertions
- Triggered on release publish and workflow_dispatch

## New files

| File | Purpose |
|---|---|
| `.github/workflows/build_wheels.yml` | CI workflow with matrix builds |
| `tools/build_ipopt_manylinux.sh` | Compile Ipopt + MUMPS + OpenBLAS for Linux |
| `tools/install_ipopt_conda.sh` | Install Ipopt from conda-forge for macOS |
| `tools/setup_ipopt_pyodide.sh` | Download pre-built wasm32 Ipopt libraries |
| `tools/strip_wasm_features.py` | Strip unsupported wasm features for Pyodide compatibility |
| `tools/append_bundled_licenses.sh` | Bundle dependency licenses into Linux wheels |
| `tools/test_wheel.py` | HS071 smoke test with assertions |

## Test plan

- [x] Linux x86_64 wheels build and pass smoke test
- [x] Linux aarch64 wheels build and pass smoke test
- [x] macOS arm64 wheels build and pass smoke test
- [x] Windows AMD64 wheels build and pass smoke test
- [x] Pyodide wasm32 wheels build and pass smoke test
- [x] All wheels uploaded as artifacts

Full green CI run: https://github.com/louisabraham/cyipopt/actions/runs/23086271664

Closes #41