### PR TITLE
Do not make copies of the bound arrays if they are provided as correctly typed and shaped NumPy arrays.

### DIFF
--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -374,11 +374,12 @@ cdef class Problem:
         if ub is None:
             ub = INF * np.ones(n)
 
-        if len(lb) != len(ub) or len(lb) != n:
-            raise ValueError("lb and ub must either be None or have length n.")
+        if len(lb) != len(ub) or lb.shape != (n,):
+            raise ValueError("lb and ub must either be None or have shape (n,).")
 
-        cdef np.ndarray[DTYPEd_t, ndim=1]  np_lb = np.array(lb, dtype=DTYPEd).flatten()
-        cdef np.ndarray[DTYPEd_t, ndim=1]  np_ub = np.array(ub, dtype=DTYPEd).flatten()
+        # Does not make a copy if lb, ub are numpy arrays with correct dtype.
+        cdef np.ndarray[DTYPEd_t, ndim=1]  np_lb = np.ascontiguousarray(lb, dtype=DTYPEd)
+        cdef np.ndarray[DTYPEd_t, ndim=1]  np_ub = np.ascontiguousarray(ub, dtype=DTYPEd)
 
         #
         # Handle the constraints
@@ -407,8 +408,9 @@ cdef class Problem:
 
         self.__m = m
 
-        cdef np.ndarray[DTYPEd_t, ndim=1]  np_cl = np.array(cl, dtype=DTYPEd).flatten()
-        cdef np.ndarray[DTYPEd_t, ndim=1]  np_cu = np.array(cu, dtype=DTYPEd).flatten()
+        # Does not make a copy if cl, cu are numpy arrays with correct dtype.
+        cdef np.ndarray[DTYPEd_t, ndim=1]  np_cl = np.ascontiguousarray(cl, dtype=DTYPEd)
+        cdef np.ndarray[DTYPEd_t, ndim=1]  np_cu = np.ascontiguousarray(cu, dtype=DTYPEd)
 
         #
         # Handle the callbacks

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -352,6 +352,8 @@ cdef class Problem:
     cdef public object __intermediate
     cdef public Index __n
     cdef public Index __m
+    cdef public object np_lb
+    cdef public object np_ub
 
     cdef public object __exception
     cdef Bool __in_ipopt_solve
@@ -380,6 +382,9 @@ cdef class Problem:
         # Does not make a copy if lb, ub are numpy arrays with correct dtype.
         cdef np.ndarray[DTYPEd_t, ndim=1]  np_lb = np.ascontiguousarray(lb, dtype=DTYPEd)
         cdef np.ndarray[DTYPEd_t, ndim=1]  np_ub = np.ascontiguousarray(ub, dtype=DTYPEd)
+
+        self.np_lb = np_lb
+        self.np_ub = np_ub
 
         #
         # Handle the constraints

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -375,7 +375,7 @@ cdef class Problem:
             ub = INF * np.ones(n)
 
         if len(lb) != len(ub) or len(lb) != n:
-            raise ValueError("lb and ub must either be None or have shape (n,).")
+            raise ValueError("lb and ub must either be None or have length n.")
 
         # Does not make a copy if lb, ub are numpy arrays with correct dtype.
         cdef np.ndarray[DTYPEd_t, ndim=1]  np_lb = np.ascontiguousarray(lb, dtype=DTYPEd)

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -374,7 +374,7 @@ cdef class Problem:
         if ub is None:
             ub = INF * np.ones(n)
 
-        if len(lb) != len(ub) or lb.shape != (n,):
+        if len(lb) != len(ub) or len(lb) != n:
             raise ValueError("lb and ub must either be None or have shape (n,).")
 
         # Does not make a copy if lb, ub are numpy arrays with correct dtype.

--- a/cyipopt/tests/integration/test_hs071.py
+++ b/cyipopt/tests/integration/test_hs071.py
@@ -7,15 +7,62 @@ import cyipopt
 def test_hs071_solve(hs071_initial_guess_fixture,
                      hs071_optimal_solution_fixture,
                      hs071_problem_instance_fixture):
-	"""Test hs071 test problem solves to the correct solution."""
-	x0 = hs071_initial_guess_fixture
-	nlp = hs071_problem_instance_fixture
-	x, info = nlp.solve(x0)
+    """Test hs071 test problem solves to the correct solution."""
 
-	expected_x, expected_J = hs071_optimal_solution_fixture
+    x0 = hs071_initial_guess_fixture
+    nlp = hs071_problem_instance_fixture
+    x, info = nlp.solve(x0)
 
-	np.testing.assert_almost_equal(info["obj_val"], expected_J)
-	np.testing.assert_allclose(x, expected_x)
+    expected_x, expected_J = hs071_optimal_solution_fixture
+
+    np.testing.assert_almost_equal(info["obj_val"], expected_J)
+    np.testing.assert_allclose(x, expected_x)
+
+
+def test_hs071_bounds_mutablity(
+    hs071_constraint_lower_bounds_fixture,
+    hs071_constraint_upper_bounds_fixture,
+    hs071_definition_instance_fixture,
+    hs071_initial_guess_fixture,
+    hs071_objective_fixture,
+    hs071_optimal_solution_fixture,
+    hs071_problem_instance_fixture,
+    hs071_variable_lower_bounds_fixture,
+    hs071_variable_upper_bounds_fixture,
+):
+    """Test hs071 test problem solves to the correct solution."""
+    x0 = hs071_initial_guess_fixture
+    expected_x, expected_J = hs071_optimal_solution_fixture
+
+    lb = np.array(hs071_variable_lower_bounds_fixture, dtype=np.float64)
+    ub = np.array(hs071_variable_upper_bounds_fixture, dtype=np.float64)
+    cl = np.array(hs071_constraint_lower_bounds_fixture, dtype=np.float64)
+    cu = np.array(hs071_constraint_upper_bounds_fixture, dtype=np.float64)
+
+    definition = hs071_definition_instance_fixture
+    definition.objective = hs071_objective_fixture
+    definition.intermediate = None
+    problem = _make_problem(definition, lb, ub, cl, cu)
+
+    print('running solve before bounds change')
+    solution1, info = problem.solve(x0)
+
+    print('The lb outside of problem is same as inside problem:')
+    print(lb is problem.np_lb)
+
+    np.testing.assert_allclose(solution1, expected_x)
+
+    # now change a value in the bounds
+    lb[0], lb[1], lb[2], lb[3] = 2.0, 2.0, 2.0, 2.0
+    ub[0], ub[1], ub[2], ub[3] = 4.0, 4.0, 4.0, 4.0
+
+    np.testing.assert_allclose(problem.np_lb, np.array([2.0, 2.0, 2.0, 2.0]))
+    np.testing.assert_allclose(problem.np_ub, np.array([4.0, 4.0, 4.0, 4.0]))
+
+    print('running solve after bounds change')
+    solution2, info = problem.solve(x0)
+
+    assert not np.allclose(solution2, expected_x)
 
 
 def test_hs071_warm_start(hs071_initial_guess_fixture,


### PR DESCRIPTION
I noticed that you cannot update the entries of the bounds arrays after the problem is instantiated. This is because a copy of the arrays is created even if the arrays are provided with the correct shape, type, and dtype. This change will avoid a copy of the array if provided in the strict sense, i.e. not "array like".

I'm not sure why `.flatten()` is there, as it presumes the arrays for the bounds can be passed in as not flattened.

- [ ] Would users have relied on this automatic flattening? I don't think there is any way to know about it unless you accidentally came upon it or read the code carefully. Maybe it needs deprecation or an alternative code path.
- [ ] Add a unit test to show you can change the array values after problem instantiation.
- [ ] Should these be accessible via attributes on Problem?