### PR TITLE
Move the compiled module into the cyipopt install directory.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           cd docs
           python -c "import ipopt_wrapper; print(ipopt_wrapper.__file__)"
+          python -c "from cyipopt import ipopt_wrapper; print(ipopt_wrapper.__file__)"
           make clean
           make html
           cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: conda install -y -v lapack "libblas=*=*netlib" "cython>=0.29.37" "ipopt=${{ matrix.ipopt-version }}" numpy>=1.26.4 pkg-config>=0.29.2 setuptools>=68.1.2 numpydoc>=1.6.0 sphinx>=7.2.6
       - name: Install CyIpopt
         run: |
-          python -m pip install --no-deps --no-build-isolation .
+          python -m pip install -v --no-deps --no-build-isolation .
           conda list
       - name: Test building documentation
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,4 +37,9 @@ jobs:
           python -m pip install --no-deps --no-build-isolation .
           conda list
       - name: Test building documentation
-        run: cd docs && make clean && make html && cd ..
+        run: |
+          cd docs
+          python -c "import ipopt_wrapper; print(ipopt_wrapper.__file__)"
+          make clean
+          make html
+          cd ..

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: pkg-config --libs --cflags ipopt
       - name: Install cyipopt
         run: |
-          python -m pip install -v --no-deps --no-build-isolation .
+          python -m pip install -v --no-deps --no-build-isolation -e .
           conda list
       - name: Test with pytest and run examples
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test with pytest and run examples
         run: |
           python -c "import cyipopt"
-          python -c "import cython.ipopt_wrapper; print(cython.ipopt_wrapper.__file__)"
+          python -c "import cyipopt.ipopt_wrapper; print(cyipopt.ipopt_wrapper.__file__)"
           conda list
           pytest
           python examples/hs071.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Test with pytest and run examples
         run: |
           python -c "import cyipopt"
+          python -c "import cython.ipopt_wrapper; print(cython.ipopt_wrapper.__file__)"
           conda list
           pytest
           python examples/hs071.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include AUTHORS
 include LICENSE
 include CHANGELOG.rst
 include README.rst
+include ipopt_wrapper.py
 recursive-include cyipopt *.py *.pyx *.pxd
 recursive-include tests *.py
 recursive-include docs Makefile *.bat *.rst *.py

--- a/cyipopt/__init__.py
+++ b/cyipopt/__init__.py
@@ -9,7 +9,7 @@ Copyright (C) 2017-2026 cyipopt developers
 License: EPL 2.0
 """
 
-from ipopt_wrapper import *
+from .ipopt_wrapper import *
 from .scipy_interface import *
 from .version import __version__
 from .exceptions import *

--- a/cyipopt/cython/ipopt_wrapper.pyx
+++ b/cyipopt/cython/ipopt_wrapper.pyx
@@ -21,7 +21,7 @@ from cyipopt.exceptions import CyIpoptEvaluationError
 from ipopt cimport *
 
 __all__ = [
-    "set_logging_level", "Problem", "IPOPT_VERSION"
+    "set_logging_level", "Problem", "IPOPT_VERSION", "STATUS_MESSAGES", "INF",
 ]
 
 IPOPT_VERSION = (IPOPT_VERSION_MAJOR, IPOPT_VERSION_MINOR, IPOPT_VERSION_RELEASE)

--- a/cyipopt/utils.py
+++ b/cyipopt/utils.py
@@ -7,7 +7,7 @@ Currently contains functions to aid with deprecation within CyIpopt.
 import warnings
 from functools import wraps
 
-from ipopt_wrapper import Problem
+from .ipopt_wrapper import Problem
 
 
 def deprecated_warning(new_name):

--- a/ipopt_wrapper.py
+++ b/ipopt_wrapper.py
@@ -1,0 +1,22 @@
+from warnings import warn
+
+msg = (f"The module {__name__} is deprecated as of version 1.7.0. Use 'from "
+       "cyipopt import ipopt_wrapper' instead of 'import ipopt_wrapper'.")
+warn(msg, DeprecationWarning, stacklevel=2)
+
+# NOTE : I assume that no one has code in the wild that does something like:
+# import ipopt_wrapper
+# ipopt_wrapper.__doc__
+# and only imports the most likely used variables which include what __all__
+# provided in ipopt_wrapper and more.
+from cyipopt.ipopt_wrapper import (
+    CREATE_PROBLEM_MSG,
+    CyIpoptEvaluationError,
+    DTYPEd,
+    DTYPEi,
+    INF,
+    IPOPT_VERSION,
+    Problem,
+    STATUS_MESSAGES,
+    set_logging_level,
+)

--- a/setup.py
+++ b/setup.py
@@ -194,4 +194,5 @@ if __name__ == "__main__":
           zip_safe=False,  # required for Py27 on Windows to work
           cmdclass={"build_ext": build_ext},
           ext_modules=EXT_MODULES,
+          py_modules='ipopt_wrapper',
           )

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,12 @@ if __name__ == "__main__":
           keywords=KEYWORDS,
           license=LICENSE,
           classifiers=CLASSIFIERS,
-          packages=[PACKAGE_NAME],
+          packages=[
+              'cyipopt',
+              'cyipopt.tests',
+              'cyipopt.tests.integration',
+              'cyipopt.tests.unit',
+          ],
           setup_requires=SETUP_REQUIRES,
           install_requires=INSTALL_REQUIRES,
           include_package_data=include_package_data,

--- a/setup.py
+++ b/setup.py
@@ -194,5 +194,5 @@ if __name__ == "__main__":
           zip_safe=False,  # required for Py27 on Windows to work
           cmdclass={"build_ext": build_ext},
           ext_modules=EXT_MODULES,
-          py_modules='ipopt_wrapper',
+          py_modules=['ipopt_wrapper'],
           )

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ def handle_ext_modules_win_32_other_ipopt():
                              include_dirs=IPOPT_INCLUDE_DIRS,
                              libraries=IPOPT_LIBS,
                              library_dirs=IPOPT_LIB_DIRS)]
-    DATA_FILES = [(sysconfig.get_path('purelib'),
+    DATA_FILES = [(os.path.join(sysconfig.get_path('purelib'), 'cyipopt'),
                   [os.path.join(IPOPT_DLL_DIRS[0], dll)
                    for dll in IPOPT_DLL])] if IPOPT_DLL else None
     include_package_data = False

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ def handle_ext_modules_win_32_other_ipopt():
     IPOPT_DLL = [file for file in os.listdir(bin_folder) if file.endswith(".dll")]
     print("Found ipopt binaries {}".format(IPOPT_DLL))
     IPOPT_DLL_DIRS = [bin_folder]
-    EXT_MODULES = [Extension("ipopt_wrapper",
+    EXT_MODULES = [Extension("cyipopt.ipopt_wrapper",
                              ["cyipopt/cython/ipopt_wrapper.pyx"],
                              include_dirs=IPOPT_INCLUDE_DIRS,
                              libraries=IPOPT_LIBS,
@@ -147,7 +147,7 @@ def handle_ext_modules_win_32_other_ipopt():
 
 
 def handle_ext_modules_general_os():
-    ipopt_wrapper_ext = Extension("ipopt_wrapper",
+    ipopt_wrapper_ext = Extension("cyipopt.ipopt_wrapper",
                                   ["cyipopt/cython/ipopt_wrapper.pyx"],
                                   **pkgconfig("ipopt"))
     EXT_MODULES = [ipopt_wrapper_ext]


### PR DESCRIPTION
Fixes #316

This would require a deprecation warning, because someone may be doing `import ipopt_wrapper`. Not sure how likely that would be.