### PR TITLE
Add SPDX license identifier to pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["cython>=0.29.37", "numpy>=1.25","setuptools>=68.1.2"]
 build-backend = "setuptools.build_meta"
+[project]
+license = "EPL-2.0"
+license-files = ["LICENSE"]


### PR DESCRIPTION
Fixes #312

Seems impossible to add this to the setup.py.